### PR TITLE
option to change sign of lat/long outside USA

### DIFF
--- a/R/DataDiscoveryRetrieval.R
+++ b/R/DataDiscoveryRetrieval.R
@@ -113,6 +113,10 @@ TADAdataRetrieval <- function(statecode = "null",
   # Retrieve all 3 profiles
   results.DR <- dataRetrieval::readWQPdata(WQPquery,
                                            ignore_attributes = TRUE)
+  #check if any results are available
+  if ((nrow(results.DR) > 0) == FALSE) {
+    stop("Your WQP query returned no results (no data available). Try a different query. Removing some of your query filters OR broadening your search area may help.")
+  }
 
   narrow.DR <- dataRetrieval::readWQPdata(WQPquery, 
                                           dataProfile = "narrowResult", 

--- a/R/ResultFlagsIndependent.R
+++ b/R/ResultFlagsIndependent.R
@@ -924,7 +924,7 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' American Samoa, Northern Mariana Islands, and Guam), 3) If the latitude or longitude
 #' contains the string, "999", the row will be flagged as invalid, and 4) Finally,
 #' precision can be measured by the number of decimal places in the latitude and longitude
-#' provided. If either the latitude or longitude does not have any numbers to the 
+#' provided. If either the latitude or longitude does not have at least three numbers to the 
 #' right of the decimal point, the row will be flagged as "Imprecise". Occasionally
 #' latitude and longitude measurements are flagged as outside of the United States
 #' because the data was entered as negative when it should be positive or vice versa.
@@ -933,7 +933,7 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' with changing raw data, email the WQX help desk: \email{WQX@@epa.gov}
 #'
 #' @param .data TADA dataframe
-#' @param clean_outsideUSA character argument with options "no", "remove", and "change sign"; 
+#' @param clean_outsideUSA Character argument with options "no", "remove", and "change sign"; 
 #' flags coordinates as outside the USA when clean_outsideUSA = "no";
 #' removes data with coordinates outside of the United States when clean_outsideUSA = "remove";
 #' changes sign of lat/long coordinates flagged as outside the USA when 
@@ -943,12 +943,13 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' @param errorsonly Boolean argument; Return only flagged data when errorsonly = TRUE;
 #' default is errorsonly = FALSE.
 #'
-#' @return When clean_outsideUSA is "no"/"change sign" or clean_imprecise argument is FALSE,
+#' @return When clean_outsideUSA is "no", "change sign", or clean_imprecise argument is FALSE,
 #' a column flagging rows with the respective QA check is appended to the input
 #' dataframe. When clean_outsideUSA is "remove" or clean_imprecise is TRUE, 
 #' "invalid" or "imprecise" data is removed, respectively. When errorsonly is TRUE, 
-#' the dataframe will be filtered to show only the "invalid" or "imprecise" data.
-#' Defaults are clean_outsideUSA = "no", clean_imprecise = FALSE, and errorsonly = FALSE.
+#' the dataframe will be filtered to show only the data flagged as invalid, imprecise, 
+#' or out of the United States. Defaults are clean_outsideUSA = "no", 
+#' clean_imprecise = FALSE, and errorsonly = FALSE.
 #'
 #' @export
 #' 
@@ -983,7 +984,10 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' # Remove data with imprecise coordinates or coordinates outside the USA from the dataframe:
 #' InvalidCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove", clean_imprecise = TRUE)
 
-InvalidCoordinates <- function(.data, clean_outsideUSA = c("no", "remove", "change sign"), clean_imprecise = FALSE, errorsonly = FALSE) {
+InvalidCoordinates <- function(.data, 
+                               clean_outsideUSA = c("no", "remove", "change sign"), 
+                               clean_imprecise = FALSE, 
+                               errorsonly = FALSE) {
   # check .data is data.frame
   checkType(.data, "data.frame", "Input object")
   # check clean_outsideUSA is character

--- a/R/ResultFlagsIndependent.R
+++ b/R/ResultFlagsIndependent.R
@@ -915,27 +915,40 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' Invalid coordinates
 #'
 #' This function identifies and flags invalid coordinate data. When
-#' clean_outsideUSA = FALSE and clean_imprecise = FALSE,
+#' clean_outsideUSA = "no" and clean_imprecise = FALSE,
 #' a column will be appended titled "TADA.InvalidCoordinates" with the following
 #' flags: 1) If the latitude is less than zero, the row will be
-#' flagged with "LAT_OutsideUSA", 2) If the longitude is greater than zero AND less than 145,
-#' the row will be flagged as "LONG_OutsideUSA", 3) If the latitude or longitude
+#' flagged with "LAT_OutsideUSA" (with the exception of American Samoa, 
+#' Northern Mariana Islands, and Guam), 2) If the longitude is greater than zero AND less than 145,
+#' the row will be flagged as "LONG_OutsideUSA" (with the exception of 
+#' American Samoa, Northern Mariana Islands, and Guam), 3) If the latitude or longitude
 #' contains the string, "999", the row will be flagged as invalid, and 4) Finally,
 #' precision can be measured by the number of decimal places in the latitude and longitude
 #' provided. If either the latitude or longitude does not have any numbers to the 
-#' right of the decimal point, the row will be flagged as "Imprecise".
+#' right of the decimal point, the row will be flagged as "Imprecise". Occasionally
+#' latitude and longitude measurements are flagged as outside of the United States
+#' because the data was entered as negative when it should be positive or vice versa.
+#' This function offers the option of clean_outsideUSA = "change sign" to fix this
+#' issue. However, data owners should fix the raw data through WQX. For assistance
+#' with changing raw data, email the WQX help desk: \email{WQX@@epa.gov}
 #'
 #' @param .data TADA dataframe
-#' @param clean_outsideUSA Boolean argument; removes data with coordinates outside
-#' of the United States when clean_outsideUSA = TRUE. Default is clean = FALSE.
+#' @param clean_outsideUSA character argument with options "no", "remove", and "change sign"; 
+#' flags coordinates as outside the USA when clean_outsideUSA = "no";
+#' removes data with coordinates outside of the United States when clean_outsideUSA = "remove";
+#' changes sign of lat/long coordinates flagged as outside the USA when 
+#' clean_outside = "change sign"; Default is clean_outsideUSA = "no".
 #' @param clean_imprecise Boolean argument; removes imprecise data when
 #' clean_imprecise = TRUE. Default is clean_imprecise = FALSE.
-#' @param errorsonly Boolean argument; Return flagged data only when errorsonly = FALSE
+#' @param errorsonly Boolean argument; Return only flagged data when errorsonly = TRUE;
+#' default is errorsonly = FALSE.
 #'
-#' @return When either the clean_outsideUSA or clean_imprecise argument is FALSE,
+#' @return When clean_outsideUSA is "no"/"change sign" or clean_imprecise argument is FALSE,
 #' a column flagging rows with the respective QA check is appended to the input
-#' dataframe. When either argument is TRUE, "invalid" or "imprecise" data is
-#' removed, respectively.
+#' dataframe. When clean_outsideUSA is "remove" or clean_imprecise is TRUE, 
+#' "invalid" or "imprecise" data is removed, respectively. When errorsonly is TRUE, 
+#' the dataframe will be filtered to show only the "invalid" or "imprecise" data.
+#' Defaults are clean_outsideUSA = "no", clean_imprecise = FALSE, and errorsonly = FALSE.
 #'
 #' @export
 #' 
@@ -955,22 +968,26 @@ QAPPDocAvailable <- function(.data, clean = FALSE) {
 #' 
 #' # Remove data with coordinates outside the USA, but keep flagged data with 
 #' # imprecise coordinates:
-#' OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE)
+#' OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove")
 #' 
-#' # Remove data with imprecise coordinates, but keep flagged data with coordinates outside the USA:
-#' # imprecise data may include a series of 999's to the right of the decimal points
+#' # Change the sign of coordinates flagged as outside the USA and keep all
+#' # flagged data:
+#' OutsideUSACoord_changed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "change sign")
+#' 
+#' # Remove data with imprecise coordinates, but keep flagged data with coordinates outside the USA;
+#' # imprecise data may include a series of 999's to the right of the decimal points;
 #' # alternatively, imprecise data may have less than 3 significant figures to the right
-#' # of the decimal point
+#' # of the decimal point:
 #' ImpreciseCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_imprecise = TRUE)
 #' 
 #' # Remove data with imprecise coordinates or coordinates outside the USA from the dataframe:
-#' InvalidCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE, clean_imprecise = TRUE)
+#' InvalidCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove", clean_imprecise = TRUE)
 
-InvalidCoordinates <- function(.data, clean_outsideUSA = FALSE, clean_imprecise = FALSE, errorsonly = FALSE) {
+InvalidCoordinates <- function(.data, clean_outsideUSA = c("no", "remove", "change sign"), clean_imprecise = FALSE, errorsonly = FALSE) {
   # check .data is data.frame
   checkType(.data, "data.frame", "Input object")
-  # check clean_outsideUSA is boolean
-  checkType(clean_outsideUSA, "logical")
+  # check clean_outsideUSA is character
+  checkType(clean_outsideUSA, "character")
   # check clean_imprecise is boolean
   checkType(clean_imprecise, "logical")
   # check .data has required columns
@@ -983,10 +1000,15 @@ InvalidCoordinates <- function(.data, clean_outsideUSA = FALSE, clean_imprecise 
   if (class(.data$LatitudeMeasure) != "numeric") {
     warning("LatitudeMeasure field must be numeric")
   }
+  # check that clean_outsideUSA is either "no", "remove", or "change sign"
+  clean_outsideUSA <- match.arg(clean_outsideUSA)
   
   # execute function after checks are passed
   .data <- .data %>%
     dplyr::mutate(TADA.InvalidCoordinates = dplyr::case_when(
+      LatitudeMeasure < -11.046934 & LatitudeMeasure > -14.548699 & LongitudeMeasure < -168.1433 & LongitudeMeasure > -171.089874 ~ NA_character_, #American Samoa
+      LatitudeMeasure < 20.553802 & LatitudeMeasure > 14.110472 & LongitudeMeasure < 146.064818 & LongitudeMeasure > 144.886331 ~ NA_character_, #Northern Mariana Islands
+      LatitudeMeasure < 13.654383 & LatitudeMeasure > 13.234189 & LongitudeMeasure < 144.956712 & LongitudeMeasure > 144.618068 ~ NA_character_, #Guam
       LatitudeMeasure < 0 ~ "LAT_OutsideUSA",
       LongitudeMeasure > 0 & LongitudeMeasure < 145 ~ "LONG_OutsideUSA",
       grepl("999", LatitudeMeasure) ~ "Imprecise_Latincludes999",
@@ -998,24 +1020,35 @@ InvalidCoordinates <- function(.data, clean_outsideUSA = FALSE, clean_imprecise 
       | sapply(.data$LongitudeMeasure, decimalplaces) < 3 ~ "Imprecise_lessthan3decimaldigits"
     ))
   
-  # clean output, remove all data with invalid station metadata
-  if ((clean_outsideUSA == TRUE) & (clean_imprecise == TRUE)) {
-    .data <- dplyr::filter(.data, is.na(TADA.InvalidCoordinates) == TRUE)
-  }
-  
-  if ((clean_outsideUSA == FALSE) & (clean_imprecise == TRUE)) {
-    .data <- dplyr::filter(.data, 
+  # if clean_imprecise is TRUE, remove imprecise station metadata
+  if (clean_imprecise == TRUE) {
+    .data <- dplyr::filter(.data,
                            TADA.InvalidCoordinates != "Imprecise_Latincludes999" 
                            & TADA.InvalidCoordinates != "Imprecise_Longincludes999"
                            & TADA.InvalidCoordinates != "Imprecise_lessthan3decimaldigits"
                            | is.na(TADA.InvalidCoordinates) == TRUE)
   }
   
-  if ((clean_outsideUSA == TRUE) & (clean_imprecise == FALSE)) {
+  # if clean_outsideUSA is "remove", remove stations flagged as outside the USA
+  if (clean_outsideUSA == "remove") {
     .data <- dplyr::filter(.data, 
                            TADA.InvalidCoordinates != "LAT_OutsideUSA" 
                            & TADA.InvalidCoordinates != "LONG_OutsideUSA"
                            | is.na(TADA.InvalidCoordinates) == TRUE)
+  }
+  
+  # if clean_outsideUSA is "change sign", change the sign of lat/long coordinates outside of USA
+  if (clean_outsideUSA == "change sign") {
+    print("Note: This is a temporary solution. Data owner should fix the raw data to address invalid coordinates through WQX. For assistance, email the WQX helpdesk (WQX@epa.gov).")
+    .data <- .data %>% 
+      dplyr::mutate(
+        LatitudeMeasure = dplyr::case_when(
+          TADA.InvalidCoordinates == "LAT_OutsideUSA" ~ LatitudeMeasure*(-1),
+          TRUE ~ LatitudeMeasure),
+        LongitudeMeasure = dplyr::case_when(
+          TADA.InvalidCoordinates == "LONG_OutsideUSA" ~ LongitudeMeasure*(-1),
+          TRUE ~ LongitudeMeasure)
+      )
   }
   
   #return only flagged data if errorsonly = true

--- a/inst/extdata/statecode.csv
+++ b/inst/extdata/statecode.csv
@@ -1,5 +1,6 @@
 "STATE","STATE_NAME","STUSAB","STATENS"
 "01","Alabama","AL","01779775"
+"02","Alaska","AK","01785533"
 "04","Arizona","AZ","01779777"
 "05","Arkansas","AR","00068085"
 "06","California","CA","01779778"
@@ -48,3 +49,11 @@
 "54","West Virginia","WV","01779805"
 "55","Wisconsin","WI","01779806"
 "56","Wyoming","WY","01779807"
+"60","American Samoa","AS","01802701"
+"66","Guam","GU","01802705"
+"69","Northern Mariana Islands","MP","01779809"
+"72","Puerto Rico","PR","Puerto Rico"
+"74","U.S. Minor Outlying Islands","UM","01878752"
+"78","U.S. Virgin Islands","VI","01802710"
+
+

--- a/man/InvalidCoordinates.Rd
+++ b/man/InvalidCoordinates.Rd
@@ -6,7 +6,7 @@
 \usage{
 InvalidCoordinates(
   .data,
-  clean_outsideUSA = FALSE,
+  clean_outsideUSA = c("no", "remove", "change sign"),
   clean_imprecise = FALSE,
   errorsonly = FALSE
 )
@@ -14,31 +14,45 @@ InvalidCoordinates(
 \arguments{
 \item{.data}{TADA dataframe}
 
-\item{clean_outsideUSA}{Boolean argument; removes data with coordinates outside
-of the United States when clean_outsideUSA = TRUE. Default is clean = FALSE.}
+\item{clean_outsideUSA}{Character argument with options "no", "remove", and "change sign";
+flags coordinates as outside the USA when clean_outsideUSA = "no";
+removes data with coordinates outside of the United States when clean_outsideUSA = "remove";
+changes sign of lat/long coordinates flagged as outside the USA when
+clean_outside = "change sign"; Default is clean_outsideUSA = "no".}
 
 \item{clean_imprecise}{Boolean argument; removes imprecise data when
 clean_imprecise = TRUE. Default is clean_imprecise = FALSE.}
 
-\item{errorsonly}{Boolean argument; Return flagged data only when errorsonly = FALSE}
+\item{errorsonly}{Boolean argument; Return only flagged data when errorsonly = TRUE;
+default is errorsonly = FALSE.}
 }
 \value{
-When either the clean_outsideUSA or clean_imprecise argument is FALSE,
+When clean_outsideUSA is "no", "change sign", or clean_imprecise argument is FALSE,
 a column flagging rows with the respective QA check is appended to the input
-dataframe. When either argument is TRUE, "invalid" or "imprecise" data is
-removed, respectively.
+dataframe. When clean_outsideUSA is "remove" or clean_imprecise is TRUE,
+"invalid" or "imprecise" data is removed, respectively. When errorsonly is TRUE,
+the dataframe will be filtered to show only the data flagged as invalid, imprecise,
+or out of the United States. Defaults are clean_outsideUSA = "no",
+clean_imprecise = FALSE, and errorsonly = FALSE.
 }
 \description{
 This function identifies and flags invalid coordinate data. When
-clean_outsideUSA = FALSE and clean_imprecise = FALSE,
+clean_outsideUSA = "no" and clean_imprecise = FALSE,
 a column will be appended titled "TADA.InvalidCoordinates" with the following
 flags: 1) If the latitude is less than zero, the row will be
-flagged with "LAT_OutsideUSA", 2) If the longitude is greater than zero AND less than 145,
-the row will be flagged as "LONG_OutsideUSA", 3) If the latitude or longitude
+flagged with "LAT_OutsideUSA" (with the exception of American Samoa,
+Northern Mariana Islands, and Guam), 2) If the longitude is greater than zero AND less than 145,
+the row will be flagged as "LONG_OutsideUSA" (with the exception of
+American Samoa, Northern Mariana Islands, and Guam), 3) If the latitude or longitude
 contains the string, "999", the row will be flagged as invalid, and 4) Finally,
 precision can be measured by the number of decimal places in the latitude and longitude
-provided. If either the latitude or longitude does not have any numbers to the
-right of the decimal point, the row will be flagged as "Imprecise".
+provided. If either the latitude or longitude does not have at least three numbers to the
+right of the decimal point, the row will be flagged as "Imprecise". Occasionally
+latitude and longitude measurements are flagged as outside of the United States
+because the data was entered as negative when it should be positive or vice versa.
+This function offers the option of clean_outsideUSA = "change sign" to fix this
+issue. However, data owners should fix the raw data through WQX. For assistance
+with changing raw data, email the WQX help desk: \email{WQX@epa.gov}
 }
 \examples{
 # Load example dataset:
@@ -56,14 +70,18 @@ InvalidCoord_flags_errorsonly <- InvalidCoordinates(Nutrients_Utah, errorsonly =
 
 # Remove data with coordinates outside the USA, but keep flagged data with 
 # imprecise coordinates:
-OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE)
+OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove")
 
-# Remove data with imprecise coordinates, but keep flagged data with coordinates outside the USA:
-# imprecise data may include a series of 999's to the right of the decimal points
+# Change the sign of coordinates flagged as outside the USA and keep all
+# flagged data:
+OutsideUSACoord_changed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "change sign")
+
+# Remove data with imprecise coordinates, but keep flagged data with coordinates outside the USA;
+# imprecise data may include a series of 999's to the right of the decimal points;
 # alternatively, imprecise data may have less than 3 significant figures to the right
-# of the decimal point
+# of the decimal point:
 ImpreciseCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_imprecise = TRUE)
 
 # Remove data with imprecise coordinates or coordinates outside the USA from the dataframe:
-InvalidCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE, clean_imprecise = TRUE)
+InvalidCoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove", clean_imprecise = TRUE)
 }

--- a/tests/testthat/test-ResultFlagsIndependent.R
+++ b/tests/testthat/test-ResultFlagsIndependent.R
@@ -20,14 +20,14 @@ test_that("InvalidCoordinates works", {
               | ImpreciseCoord_removed$TADA.InvalidCoordinates!="Imprecise_lessthan3decimaldigits"))
   
   # Remove data with coordinates outside the USA, but keep flagged data with imprecise coordinates:
-  OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE)
+  OutsideUSACoord_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove")
   unique(OutsideUSACoord_removed$TADA.InvalidCoordinates)
   
   expect_true(any(OutsideUSACoord_removed$TADA.InvalidCoordinates!="LONG_OutsideUSA" 
                   | OutsideUSACoord_removed$TADA.InvalidCoordinates!="LAT_OutsideUSA"))
   
   ## Remove data with imprecise coordinates or coordinates outside the USA from the dataframe:
-  Invalid_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = TRUE, clean_imprecise = TRUE)
+  Invalid_removed <- InvalidCoordinates(Nutrients_Utah, clean_outsideUSA = "remove", clean_imprecise = TRUE)
   unique(Invalid_removed$TADA.InvalidCoordinates)
   
 })
@@ -60,7 +60,7 @@ test_that("Imprecise_lessthan3decimaldigits works again", {
   FLAGSONLY <- dplyr::filter(FLAGSONLY, sapply(FLAGSONLY$LatitudeMeasure, decimalplaces) < 3)
   
   check = sapply(FLAGSONLY$LatitudeMeasure, decimalplaces) < 4
-         
-  expect_true(unique(check))
   
+  expect_true(unique(check))
 })
+

--- a/vignettes/WQPDataHarmonization.Rmd
+++ b/vignettes/WQPDataHarmonization.Rmd
@@ -103,7 +103,8 @@ characteristicName = "pH".
 
 Data retrieval filters include:
 
--   statecode
+-   statecode (review list of possible state and territory
+    [abbreviations](https://www2.census.gov/geo/docs/reference/state.txt))
 
 -   endDate
 

--- a/vignettes/WQPDataHarmonization.Rmd
+++ b/vignettes/WQPDataHarmonization.Rmd
@@ -57,9 +57,9 @@ Uncomment the lines below to install latest version of TADA and
 dataRetrieval from GitHub.
 
 ```{r, results = 'hide', message = FALSE, warning = FALSE}
-remotes::install_github("USGS-R/dataRetrieval", dependencies=TRUE)
+# remotes::install_github("USGS-R/dataRetrieval", dependencies=TRUE)
 
-remotes::install_github("hadley/ggplot2", dependencies=TRUE)
+# remotes::install_github("hadley/ggplot2", dependencies=TRUE)
 
 remotes::install_github("USEPA/TADA", dependencies=TRUE)
 ```
@@ -289,7 +289,7 @@ points(TADAProfile$LongitudeMeasure, TADAProfile$LatitudeMeasure, col="red", pch
 The TADA InvalidCoordinates function identifies and flags invalid
 coordinate data.
 
-When clean_outsideUSA = FALSE and clean_imprecise = FALSE, a column will
+When clean_outsideUSA = "no" and clean_imprecise = FALSE, a column will
 be appended titled "TADA.InvalidCoordinates" with the following flags
 (if relevant to dataframe).
 
@@ -308,7 +308,7 @@ be appended titled "TADA.InvalidCoordinates" with the following flags
     as "Imprecise".
 
 ```{r}
-TADAProfileClean1 <- InvalidCoordinates(TADAProfile, clean_outsideUSA = TRUE, clean_imprecise = FALSE)
+TADAProfileClean1 <- InvalidCoordinates(TADAProfile, clean_outsideUSA = "no", clean_imprecise = FALSE)
 
 #redraw map after all rows with invalid LAT/LONG data are removed
 map('county', 'utah')

--- a/vignettes/WQPDataHarmonization.Rmd
+++ b/vignettes/WQPDataHarmonization.Rmd
@@ -290,15 +290,37 @@ points(TADAProfile$LongitudeMeasure, TADAProfile$LatitudeMeasure, col="red", pch
 The TADA InvalidCoordinates function identifies and flags invalid
 coordinate data.
 
-When clean_outsideUSA = "no" and clean_imprecise = FALSE, a column will
-be appended titled "TADA.InvalidCoordinates" with the following flags
-(if relevant to dataframe).
+Allowable values for clean_outsideUSA are "no", "remove", or "change
+sign". The default is "no" which flags latitude and longitude
+coordinates outside the USA. Assigning clean_ousideUSA = "remove" will
+remove rows of data with coordinates outside the USA. And assigning
+clean_outsideUSA = "change sign" will flip the sign of latitude or
+longitude coordinates flagged as outside the USA. The "change sign"
+option should only be used when it is known that coordinates were
+entered with the wrong sign in WQX; additionally, the data ower should
+fix these incorrect coordinates in the raw data through the WQX - for
+assistance email the WQX help desk: WQX\@epa.gov
+
+Allowable values for clean_imprecise are TRUE or FALSE. The default is
+FALSE which flags rows of data with invalid or imprecise coordinates.
+Assigning clean_imprecise = TRUE will remove rows of data with invalid
+or imprecise coordinates.
+
+Allowable values for errorsonly are TRUE or FALSE. The default is FALSE
+which keeps all rows of data regardless of flag status. Assigning
+errorsonly = TRUE filters the dataframe to show only rows of data which
+are flagged.
+
+When clean_outsideUSA = "no" and/or clean_imprecise = FALSE, a column
+will be appended titled "TADA.InvalidCoordinates" with the following
+flags (if relevant to dataframe):
 
 -   If the latitude is less than zero, the row will be flagged with
-    "LAT_OutsideUSA".
+    "LAT_OutsideUSA". (Exception for American Samoa)
 
 -   If the longitude is greater than zero AND less than 145, the row
-    will be flagged as "LONG_OutsideUSA".
+    will be flagged as "LONG_OutsideUSA". (Exceptions for Guam and the
+    Northern Mariana Islands)
 
 -   If the latitude or longitude contains the string, "999", the row
     will be flagged as invalid.
@@ -392,11 +414,20 @@ ResultDetectionConditionText = "Reported in Raw Data (attached)".
     from the dataframe and no column will be appended. The default is
     clean = TRUE.
 
+An additional input called errorsonly will allow the user to filter data
+to show only rows of aggregated continuous data. Allowable values for
+errorsonly are TRUE or FALSE. The default is FALSE which keeps all rows
+of data regardless of flag status. Assigning errorsonly = TRUE filters
+the dataframe to show only rows of data which are flagged "Y".
+
 See function documentation for additional function options by entering
 the following code in the console: ?AggregatedContinuousData
 
 ```{r}
 TADAProfileClean4 <- AggregatedContinuousData(TADAProfileClean3, clean = TRUE)
+
+# uncomment below to create a dataframe of only the aggregated continuous data
+# TADAProfile_aggcont <- AggregatedContinuousData(TADAProfileClean3, clean = FALSE, errorsonly = TRUE)
 ```
 
 ## WQX QAQC Service Result Flags
@@ -410,7 +441,7 @@ See documentation for more details:
 
 -   ?InvalidMethod
 
-    -   When Clean = FALSE, this function adds the following column to
+    -   When clean = FALSE, this function adds the following column to
         your dataframe: WQX.AnalyticalMethodValidity. This column flags
         invalid CharacteristicName,
         ResultAnalyticalMethod/MethodIdentifier, and
@@ -419,6 +450,9 @@ See documentation for more details:
 
     -   When clean = TRUE, "Invalid" rows are removed from the dataframe
         and no column will be appended.
+
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as "Invalid"; default is errorsonly = FALSE.
 
 -   ?InvalidSpeciation
 
@@ -431,6 +465,9 @@ See documentation for more details:
     -   When clean = TRUE, "Invalid" rows are removed from the dataframe
         and no column will be appended.
 
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as "Invalid"; default is errorsonly = FALSE.
+
 -   ?InvalidResultUnit
 
     -   When clean = FALSE, the following column will be added to your
@@ -442,6 +479,9 @@ See documentation for more details:
     -   When clean = TRUE, "Invalid" rows are removed from the dataframe
         and no column will be appended.
 
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as "Invalid"; default is errorsonly = FALSE.
+
 -   ?InvalidFraction
 
     -   When clean = FALSE, this function adds the following column to
@@ -451,6 +491,8 @@ See documentation for more details:
         "Valid".
     -   When clean = TRUE, "Invalid" rows are removed from the dataframe
         and no column will be appended.
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as "Invalid"; default is errorsonly = FALSE.
 
 ```{r}
 TADAProfileClean5 <- InvalidMethod(TADAProfileClean4, clean = TRUE)
@@ -474,6 +516,10 @@ combination. See documentation for more details:
     -   When clean = TRUE, data that is above the upper WQX threshold is
         removed from the dataframe.
 
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as above the upper WQX threshold; default is
+        errorsonly = FALSE.
+
 -   ?BelowNationalWQXLowerThreshold
 
     -   When clean = FALSE, the following column is added to your
@@ -482,6 +528,10 @@ combination. See documentation for more details:
 
     -   When clean = TRUE, data that is below the lower WQX threshold is
         removed from the dataframe.
+
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as below the lower WQX threshold; default is
+        errorsonly = FALSE.
 
 The default is clean=TRUE, but you can change this to only flag results
 if desired. Results will be flagged, but not removed, when clean=FALSE.
@@ -513,6 +563,10 @@ the following into the console:
         duplicate rows will be removed from the dataframe and no column
         is appended.
 
+    -   When errorsonly = TRUE, the dataframe is filtered to only the
+        rows flagged as potential duplicates; default is errorsonly =
+        FALSE.
+
 When clean = TRUE, the function retains the first occurrence of each
 potential duplicate in the dataframe. Default is clean = TRUE.
 
@@ -530,15 +584,18 @@ to indicate if the data produced has an approved Quality Assurance
 Project Plan (QAPP) or not. In this field, Y indicates yes, N indicates
 no.
 
-This function has two default inputs: clean = TRUE and cleanNA = FALSE.
-These defaults remove rows of data where the QAPPApprovedIndicator
-equals "N".
+This function has three default inputs: clean = TRUE, cleanNA = FALSE,
+and errorsonly = FALSE. These defaults remove rows of data where the
+QAPPApprovedIndicator equals "N".
 
 Users could alternatively remove both N's and NA's using the inputs
-clean = TRUE and cleanNA = TRUE.
+clean = TRUE, cleanNA = TRUE, and errorsonly = FALSE.
 
-If both clean = FALSE and cleanNA = FALSE, the function will not do
-anything.
+Additionally, users could filter to show only N's and NA's by using the
+inputs clean = FALSE, cleanNA = FALSE, and errorsonly = TRUE.
+
+If clean = FALSE, cleanNA = FALSE, and errorsonly = FALSE, the function
+will not do anything.
 
 ```{r}
 TADAProfileClean12 <- QAPPapproved(TADAProfileClean11, clean = TRUE, cleanNA = FALSE)
@@ -551,8 +608,11 @@ determine if a QAPP document is available to review. When clean = FALSE,
 a column will be appended to flag results that do have an associated
 QAPP document URL provided. When clean = TRUE, rows that do not have an
 associated QAPP document are removed from the dataframe and no column
-will be appended. This function should only be used to remove data if an
-accompanying QAPP document is required to use data in assessments.
+will be appended. When errorsonly = TRUE, the dataframe is filtered to
+show only rows that do not have an associated QAPP document. The
+defaults are clean = FALSE and errorsonly = FALSE. This function should
+only be used to remove data if an accompanying QAPP document is required
+to use data in assessments.
 
 ```{r}
 TADAProfileClean13 <- QAPPDocAvailable(TADAProfileClean12, clean = FALSE)


### PR DESCRIPTION
Changed clean_outsideUSA argument in InvalidCoordinates() to accept three options: "no" (default), "remove", or "change sign" to address issue #177
Question: after changing the sign of coordinates outside the USA, should the flag from TADA.InvalidCoordinates column be removed? (I left it in, so it will still show up if errorsonly = TRUE.)