### PR TITLE
InvalidResultUnit function update

### DIFF
--- a/R/ResultFlagsDependent.R
+++ b/R/ResultFlagsDependent.R
@@ -209,6 +209,7 @@ InvalidSpeciation <- function(.data, clean = c("invalid_only", "nonstandardized_
   if (("WQX.MethodSpeciationValidity" %in% colnames(.data)) == TRUE) {
     .data <- dplyr::select(.data, -WQX.MethodSpeciationValidity)
   }
+  
   # read in speciation reference table from extdata and filter
   spec.ref <- GetWQXCharValRef() %>%
     dplyr::filter(Type == "CharacteristicSpeciation")
@@ -265,7 +266,7 @@ InvalidSpeciation <- function(.data, clean = c("invalid_only", "nonstandardized_
   # when clean = "both"
   if (clean == "both") {
     # filter out both "Invalid" and "Nonstandardized" characteristic-method speciation combinations
-    clean.data <- dplyr::filter(check.data, WQX.MethodSpeciationValidity != "Nonstandardized" | WQX.MethodSpeciationValidity != "Invalid")
+    clean.data <- dplyr::filter(check.data, WQX.MethodSpeciationValidity != "Nonstandardized" & WQX.MethodSpeciationValidity != "Invalid")
   }
   
   # when clean = "none"
@@ -296,28 +297,36 @@ InvalidSpeciation <- function(.data, clean = c("invalid_only", "nonstandardized_
 #' Check Result Unit Validity
 #'
 #' Function checks the validity of each characteristic-media-result unit
-#' combination in the dataframe. When clean = TRUE, rows 
-#' with invalid characteristic-media-result unit combinations are removed. Default is
-#' clean = TRUE. When errorsonly = TRUE, dataframe is filtered to show only rows
-#' with invalid characteristic-media-result unit combinations. Default is
-#' errorsonly = FALSE.
+#' combination in the dataframe. When clean = "invalid_only", rows with invalid
+#' characteristic-media-result unit combinations are removed. Default is
+#' clean = "invalid_only". When errorsonly = TRUE, dataframe is filtered to show only
+#' rows with invalid or nonstandardized characteristic-media-result unit combinations. 
+#' Default is errorsonly = FALSE.
 #'
 #' @param .data TADA dataframe
-#' @param clean Boolean argument; removes "Invalid" characteristic-media-result
-#' unit combinations from the dataframe when clean = TRUE. Default is
-#' clean = TRUE.
+#' @param clean Character argument with options "invalid_only", "nonstandardized_only", 
+#' "both", or "none." The default is clean = "invalid_only" which removes rows of
+#' data flagged as having "Invalid" characteristic-media-result unit combinations. When
+#' clean = "nonstandardized_only", the function removes rows of data flagged as
+#' having "Nonstandardized" characteristic-media-result unit combinations. When 
+#' clean = "both", the function removes rows of data flagged as either "Invalid" or
+#' "Nonstandardized". And when clean = "none", the function does not remove any "Invalid"
+#' or "Nonstandardized" rows of data.
 #' @param errorsonly Boolean argument; filters dataframe to show only "Invalid"
 #' characteristic-media-result unit combinations when errorsonly = TRUE. Default
 #' is errorsonly = FALSE.
 #'
-#' @return When clean = FALSE and errorsonly = FALSE, the following column will 
-#' be added to your dataframe: WQX.ResultUnitValidity. This column flags each 
-#' CharacteristicName, ActivityMediaName, and ResultMeasure/MeasureUnitCode 
+#' @return When clean = "none" and errorsonly = FALSE, this function adds the 
+#' following column to your dataframe: WQX.ResultUnitValidity. This column 
+#' flags each CharacteristicName, ActivityMediaName, and ResultMeasure/MeasureUnitCode
 #' combination in your dataframe as either "Nonstandardized", "Invalid", or "Valid". 
-#' When clean = FALSE and errorsonly = TRUE, the dataframe will be filtered to 
-#' show only "Invalid" characteristic-media-result unit combinations;
-#' WQX.ResultUnitValidity column is still appended. When clean = TRUE, "Invalid" 
-#' rows are removed from the dataframe and no column will be appended.
+#' When clean = "none" and errorsonly = TRUE, the dataframe is filtered to show only 
+#' the "Invalid" and "Nonstandardized data; the column WQX.ResultUnitValidity is 
+#' still appended. When clean = "invalid_only" and errorsonly = FALSE, "Invalid" 
+#' rows are removed from the dataframe, but "Nonstandardized" rows are retained. When
+#' clean = "nonstandardized_only" and errorsonly = FALSE, "Nonstandardized" rows
+#' are removed, but "Invalid" rows are retained. The default is clean = "invalid_only"
+#' and errorsonly = FALSE.
 #'
 #' @export
 #'
@@ -325,35 +334,46 @@ InvalidSpeciation <- function(.data, clean = c("invalid_only", "nonstandardized_
 #' # Load example dataset:
 #' data(Nutrients_Utah)
 #' 
-#' # Remove invalid characteristic-media-result unit combinations from dataframe:
-#' ResultUnitValidity_clean <- InvalidResultUnit(Nutrients_Utah)
+#' # Remove data with invalid characteristic-media-result unit combinations from dataframe, 
+#' # but retain nonstandardized combinations flagged in new column 'WQX.ResultUnitValidity':
+#' InvalidUnit_clean <- InvalidResultUnit(Nutrients_Utah)
 #' 
-#' # Flag, but do not remove, invalid characteristic-media-result unit combinations
-#' # in new column titled "WQX.ResultUnitValidity":
-#' ResultUnitValidity_flags <- InvalidResultUnit(Nutrients_Utah, clean = FALSE)
+#' # Remove data with nonstandardized characteristic-media-result unit combinations 
+#' # from dataframe but retain invalid combinations flagged in new column 'WQX.ResultUnitValidity':
+#' NonstandardUnit_clean <- InvalidResultUnit(Nutrients_Utah, clean = "nonstandardized_only")
+#' 
+#' # Remove both invalid and nonstandardized characteristic-media-result unit combinations
+#' # from dataframe:
+#' ResultUnit_clean <- InvalidResultUnit(Nutrients_Utah, clean = "both")
+#' 
+#' # Flag, but do not remove, data with invalid or nonstandardized characteristic-media-result unit
+#' # combinations in new column titled "WQX.ResultUnitValidity":
+#' InvalidUnit_flags <- InvalidResultUnit(Nutrients_Utah, clean = "none")
 #' 
 #' # Show only invalid characteristic-media-result unit combinations:
-#' ResultUnitValidity_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = FALSE, errorsonly = TRUE)
+#' InvalidUnit_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = "nonstandardized_only", errorsonly = TRUE)
+#' 
+#' # Show only nonstandardized characteristic-media-result unit combinations:
+#' NonstandardUnit_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = "invalid_only", errorsonly = TRUE)
 
 
-InvalidResultUnit <- function(.data, clean = TRUE, errorsonly = FALSE) {
+InvalidResultUnit <- function(.data, clean = c("invalid_only", "nonstandardized_only", "both", "none"), errorsonly = FALSE) {
   # check .data is data.frame
   checkType(.data, "data.frame", "Input object")
-  # check clean is boolean
-  checkType(clean, "logical")
+  # check clean is character
+  checkType(clean, "character")
   # check errorsonly is boolean
   checkType(errorsonly, "logical")
   # check .data has required columns
   checkColumns(.data, c("CharacteristicName", "ResultMeasure.MeasureUnitCode", "ActivityMediaName"))
-  # check that clean and errorsonly are not both TRUE
-  if (clean == TRUE & errorsonly == TRUE) {
-    stop("Function not executed because clean and errorsonly cannot both be TRUE")
-  }
+  # check that clean is either "invalid_only", "nonstandardized_only", "both", or "none"
+  clean <- match.arg(clean)
 
   # execute function after checks are passed
   if (("WQX.ResultUnitValidity" %in% colnames(.data)) == TRUE) {
     .data <- dplyr::select(.data, -WQX.ResultUnitValidity)
   }
+  
   # read in unit reference table from extdata and filter
   unit.ref <- GetWQXCharValRef() %>%
     dplyr::filter(Type == "CharacteristicUnit")
@@ -391,30 +411,48 @@ InvalidResultUnit <- function(.data, clean = TRUE, errorsonly = FALSE) {
   }
   
   # flagged output, all data
-  if (clean == FALSE & errorsonly == FALSE) {
-    return(check.data)
-    warning("Metadata transformations may be adversely affected by choosing to retain 'Invalid' result units. In order to ensure transformation functions will run properly, set clean = TRUE.")
+  if (clean == "none" & errorsonly == FALSE) {
+    warning("Metadata transformations may be adversely affected by choosing to retain 'Invalid' result units. In order to ensure transformation functions will run properly, set clean = 'invalid_only' or 'both'.")
   }
   
-  # clean output
-  if (clean == TRUE & errorsonly == FALSE) {
-    # filter out invalid characteristic-unit-media combinations
+  # when clean = "invalid_only"
+  if (clean == "invalid_only") {
+    # filter out only "Invalid" characteristic-method speciation combinations
     clean.data <- dplyr::filter(check.data, WQX.ResultUnitValidity != "Invalid")
-    
-    # remove WQX.ResultUnitValidity column
-    clean.data <- dplyr::select(clean.data, -WQX.ResultUnitValidity)
-    
+  }
+  
+  # when clean = "nonstandardized_only"
+  if (clean == "nonstandardized_only") {
+    # filter out only "Nonstandardized" characteristic-method speciation combinations
+    clean.data <- dplyr::filter(check.data, WQX.ResultUnitValidity != "Nonstandardized")
+  }
+  
+  # when clean = "both"
+  if (clean == "both") {
+    # filter out both "Invalid" and "Nonstandardized" characteristic-method speciation combinations
+    clean.data <- dplyr::filter(check.data, WQX.ResultUnitValidity != "Nonstandardized" & WQX.ResultUnitValidity != "Invalid")
+  }
+  
+  # when clean = "none"
+  if (clean == "none") {
+    # retain all data
+    clean.data <- check.data
+  }
+  
+  # when errorsonly = FALSE
+  if (errorsonly == FALSE) {
     return(clean.data)
   }
   
-  # flagged output, errors only
-  if (clean == FALSE & errorsonly == TRUE) {
-    # filter to show only invalid characteristic-unit-media combinations
-    invalid.data <- dplyr::filter(check.data, WQX.ResultUnitValidity == "Invalid")
-    if (nrow(invalid.data) == 0) {
-      print("This dataframe is empty because we did not find any invalid characteristic-unit-media combinations in your dataframe")
-      invalid.data <- dplyr::select(invalid.data, -WQX.ResultUnitValidity)
+  # when errorsonly = TRUE
+  if (errorsonly == TRUE) {
+    # filter to show only invalid and/or nonstandardized characteristic-method speciation combinations
+    error.data <- dplyr::filter(clean.data, WQX.ResultUnitValidity == "Invalid" | WQX.ResultUnitValidity == "Nonstandardized")
+    # if there are no errors
+    if (nrow(error.data) == 0) {
+      print("This dataframe is empty because either we did not find any invalid/nonstandardized characteristic-media-result unit combinations or they were all filtered out")
+      error.data <- dplyr::select(error.data, -WQX.ResultUnitValidity)
     }
-    return(invalid.data)
+    return(error.data)
   }
 }

--- a/man/InvalidResultUnit.Rd
+++ b/man/InvalidResultUnit.Rd
@@ -4,48 +4,72 @@
 \alias{InvalidResultUnit}
 \title{Check Result Unit Validity}
 \usage{
-InvalidResultUnit(.data, clean = TRUE, errorsonly = FALSE)
+InvalidResultUnit(
+  .data,
+  clean = c("invalid_only", "nonstandardized_only", "both", "none"),
+  errorsonly = FALSE
+)
 }
 \arguments{
 \item{.data}{TADA dataframe}
 
-\item{clean}{Boolean argument; removes "Invalid" characteristic-media-result
-unit combinations from the dataframe when clean = TRUE. Default is
-clean = TRUE.}
+\item{clean}{Character argument with options "invalid_only", "nonstandardized_only",
+"both", or "none." The default is clean = "invalid_only" which removes rows of
+data flagged as having "Invalid" characteristic-media-result unit combinations. When
+clean = "nonstandardized_only", the function removes rows of data flagged as
+having "Nonstandardized" characteristic-media-result unit combinations. When
+clean = "both", the function removes rows of data flagged as either "Invalid" or
+"Nonstandardized". And when clean = "none", the function does not remove any "Invalid"
+or "Nonstandardized" rows of data.}
 
 \item{errorsonly}{Boolean argument; filters dataframe to show only "Invalid"
 characteristic-media-result unit combinations when errorsonly = TRUE. Default
 is errorsonly = FALSE.}
 }
 \value{
-When clean = FALSE and errorsonly = FALSE, the following column will
-be added to your dataframe: WQX.ResultUnitValidity. This column flags each
-CharacteristicName, ActivityMediaName, and ResultMeasure/MeasureUnitCode
+When clean = "none" and errorsonly = FALSE, this function adds the
+following column to your dataframe: WQX.ResultUnitValidity. This column
+flags each CharacteristicName, ActivityMediaName, and ResultMeasure/MeasureUnitCode
 combination in your dataframe as either "Nonstandardized", "Invalid", or "Valid".
-When clean = FALSE and errorsonly = TRUE, the dataframe will be filtered to
-show only "Invalid" characteristic-media-result unit combinations;
-WQX.ResultUnitValidity column is still appended. When clean = TRUE, "Invalid"
-rows are removed from the dataframe and no column will be appended.
+When clean = "none" and errorsonly = TRUE, the dataframe is filtered to show only
+the "Invalid" and "Nonstandardized data; the column WQX.ResultUnitValidity is
+still appended. When clean = "invalid_only" and errorsonly = FALSE, "Invalid"
+rows are removed from the dataframe, but "Nonstandardized" rows are retained. When
+clean = "nonstandardized_only" and errorsonly = FALSE, "Nonstandardized" rows
+are removed, but "Invalid" rows are retained. The default is clean = "invalid_only"
+and errorsonly = FALSE.
 }
 \description{
 Function checks the validity of each characteristic-media-result unit
-combination in the dataframe. When clean = TRUE, rows
-with invalid characteristic-media-result unit combinations are removed. Default is
-clean = TRUE. When errorsonly = TRUE, dataframe is filtered to show only rows
-with invalid characteristic-media-result unit combinations. Default is
-errorsonly = FALSE.
+combination in the dataframe. When clean = "invalid_only", rows with invalid
+characteristic-media-result unit combinations are removed. Default is
+clean = "invalid_only". When errorsonly = TRUE, dataframe is filtered to show only
+rows with invalid or nonstandardized characteristic-media-result unit combinations.
+Default is errorsonly = FALSE.
 }
 \examples{
 # Load example dataset:
 data(Nutrients_Utah)
 
-# Remove invalid characteristic-media-result unit combinations from dataframe:
-ResultUnitValidity_clean <- InvalidResultUnit(Nutrients_Utah)
+# Remove data with invalid characteristic-media-result unit combinations from dataframe, 
+# but retain nonstandardized combinations flagged in new column 'WQX.ResultUnitValidity':
+InvalidUnit_clean <- InvalidResultUnit(Nutrients_Utah)
 
-# Flag, but do not remove, invalid characteristic-media-result unit combinations
-# in new column titled "WQX.ResultUnitValidity":
-ResultUnitValidity_flags <- InvalidResultUnit(Nutrients_Utah, clean = FALSE)
+# Remove data with nonstandardized characteristic-media-result unit combinations 
+# from dataframe but retain invalid combinations flagged in new column 'WQX.ResultUnitValidity':
+NonstandardUnit_clean <- InvalidResultUnit(Nutrients_Utah, clean = "nonstandardized_only")
+
+# Remove both invalid and nonstandardized characteristic-media-result unit combinations
+# from dataframe:
+ResultUnit_clean <- InvalidResultUnit(Nutrients_Utah, clean = "both")
+
+# Flag, but do not remove, data with invalid or nonstandardized characteristic-media-result unit
+# combinations in new column titled "WQX.ResultUnitValidity":
+InvalidUnit_flags <- InvalidResultUnit(Nutrients_Utah, clean = "none")
 
 # Show only invalid characteristic-media-result unit combinations:
-ResultUnitValidity_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = FALSE, errorsonly = TRUE)
+InvalidUnit_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = "nonstandardized_only", errorsonly = TRUE)
+
+# Show only nonstandardized characteristic-media-result unit combinations:
+NonstandardUnit_errorsonly <- InvalidResultUnit(Nutrients_Utah, clean = "invalid_only", errorsonly = TRUE)
 }

--- a/vignettes/WQPDataHarmonization.Rmd
+++ b/vignettes/WQPDataHarmonization.Rmd
@@ -544,7 +544,7 @@ See documentation for more details:
 TADAProfileClean5 <- InvalidMethod(TADAProfileClean4, clean = TRUE)
 TADAProfileClean6 <- InvalidFraction(TADAProfileClean5, clean = TRUE)
 TADAProfileClean7 <- InvalidSpeciation(TADAProfileClean6, clean = "none")
-TADAProfileClean8 <- InvalidResultUnit(TADAProfileClean7, clean = FALSE)
+TADAProfileClean8 <- InvalidResultUnit(TADAProfileClean7, clean = "none")
 ```
 
 ## WQX national upper and lower thresholds


### PR DESCRIPTION
Added options to clean argument in InvalidResultUnit function to be able to clean invalid data only, nonstandardized data only, both, or neither.