### PR TITLE
358 measurequalifiercode definitions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Imports:
     data.table, 
     dplyr,
     tidyr,
+    purrr,
     grDevices,
     magrittr,
     stringr,

--- a/R/Maintenance.R
+++ b/R/Maintenance.R
@@ -131,7 +131,7 @@ FindSynonyms <- function() {
 #
 #     testing2 <- TADA_FlagMeasureQualifierCode(testing)
 #
-#     #expect_true(all(testing2$TADA.MeasureQualifierCode.Flag != "uncategorized"))
+#     #expect_true(all(testing2$TADA.MeasureQualifierCode.Flag != "Not Reviewed"))
 #
 #     #print(unique(testing2$TADA_FlagMeasureQualifierCode))
 #     #print(unique(testing2$MeasureQualifierCode))
@@ -144,7 +144,7 @@ FindSynonyms <- function() {
 #     codes = unique(testing2$MeasureQualifierCode)
 #     missing_codes = codes[!codes %in% qc.ref$MeasureQualifierCode]
 #
-#     missing_codes_df <- data.frame(MeasureQualifierCode = missing_codes, TADA.MeasureQualifierCode.Flag = "uncategorized")
+#     missing_codes_df <- data.frame(MeasureQualifierCode = missing_codes, TADA.MeasureQualifierCode.Flag = "Not Reviewed")
 #
 #     View(missing_codes_df)
 #

--- a/R/ResultFlagsDependent.R
+++ b/R/ResultFlagsDependent.R
@@ -626,7 +626,7 @@ TADA_AutoFilter <- function(.data) {
 #' rows of data flagged as Suspect.
 #' 
 #' @param define Boolean argument; the default is define = TRUE. When define = TRUE,
-#' the function will add an additional column (TADA.MethodQualifierCode) providing 
+#' the function will add an additional column (TADA.MethodQualifierCode.Def) providing 
 #' all available definitions for the MethodQualifierCodes for each result. When 
 #' define = FALSE, no additional column is added.
 #'
@@ -690,9 +690,9 @@ TADA_FlagMeasureQualifierCode <- function(.data, clean = FALSE, flaggedonly = FA
      tidyr::unnest(MeasureQualifierCode) %>%
      merge(mqc.ref) %>%
      dplyr::group_by(ResultIdentifier) %>%
-     dplyr::summarize(TADA.MeasureQualifierCode.Define = paste(Concat, collapse = "; "))
+     dplyr::summarize(TADA.MeasureQualifierCode.Def = paste(Concat, collapse = "; "))
 
-   .data$TADA.MeasureQualifierCode.Define <- mqc.TADA$TADA.MeasureQualifierCode.Define[match(.data$ResultIdentifier, mqc.TADA$ResultIdentifier)]
+   .data$TADA.MeasureQualifierCode.Def <- mqc.TADA$TADA.MeasureQualifierCode.Def[match(.data$ResultIdentifier, mqc.TADA$ResultIdentifier)]
 
    rm(mqc.ref, mqc.TADA)
  }

--- a/R/ResultFlagsDependent.R
+++ b/R/ResultFlagsDependent.R
@@ -727,7 +727,7 @@ TADA_FlagMeasureQualifierCode <- function(.data, clean = FALSE, flaggedonly = FA
     missing_codes <- codes[!codes %in% qc.ref$MeasureQualifierCode]
     missing_codes_df <- data.frame(
       MeasureQualifierCode = missing_codes,
-      TADA.MeasureQualifierCode.Flag = "uncategorized",
+      TADA.MeasureQualifierCode.Flag = "Not Reviewed",
       Description = ""
     )
     qc.ref <- rbind(qc.ref, missing_codes_df)

--- a/R/ResultFlagsDependent.R
+++ b/R/ResultFlagsDependent.R
@@ -626,7 +626,7 @@ TADA_AutoFilter <- function(.data) {
 #' rows of data flagged as Suspect.
 #' 
 #' @param define Boolean argument; the default is define = TRUE. When define = TRUE,
-#' the function will add an additional column (TADA.MethodQualifierCode.Def) providing 
+#' the function will add an additional column (TADA.MeasureQualifierCode.Def) providing 
 #' all available definitions for the MethodQualifierCodes for each result. When 
 #' define = FALSE, no additional column is added.
 #'

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -50,7 +50,7 @@ utils::globalVariables(c(
   "SummationName", "SummationRank", "SummationFractionNotes", "SummationSpeciationNotes",
   "SummationSpeciationConversionFactor", "SummationNote", "NutrientGroup",
   "Target.Speciation", "TADA.NearbySiteGroups", "numres", "TADA.SingleOrgDupGroupID",
-  "TADA.MeasureQualifierCode.Flag", "MeasureQualifierCode", "TADA.MeasureQualifierCode.Define", "value", "Flag_Column",
+  "TADA.MeasureQualifierCode.Flag", "TADA.MeasureQualifierCode.Def", "MeasureQualifierCode", "value", "Flag_Column",
   "Data_NCTCShepherdstown_HUC12", "ActivityStartDateTime", "TADA.MultipleOrgDupGroupID",
   "TADA.WQXVal.Flag"
 ))
@@ -208,7 +208,7 @@ TADA_AutoClean <- function(.data) {
 
   # Identify QC data
   .data <- TADA_FindQCActivities(.data, clean = FALSE, flaggedonly = FALSE)
-  
+
   # change latitude and longitude measures to class numeric
   .data$TADA.LatitudeMeasure <- as.numeric(.data$LatitudeMeasure)
   .data$TADA.LongitudeMeasure <- as.numeric(.data$LongitudeMeasure)
@@ -591,7 +591,7 @@ TADA_OrderCols <- function(.data) {
     "TADA.ResultMeasureValueDataTypes.Flag",
     "TADA.ResultValueAggregation.Flag",
     "TADA.MeasureQualifierCode.Flag",
-    "TADA.MeasureQualifierCode.Define",
+    "TADA.MeasureQualifierCode.Def",
     "TADA.CensoredData.Flag",
     "TADA.CensoredMethod",
     "TADA.NutrientSummation.Flag",

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -50,7 +50,7 @@ utils::globalVariables(c(
   "SummationName", "SummationRank", "SummationFractionNotes", "SummationSpeciationNotes",
   "SummationSpeciationConversionFactor", "SummationNote", "NutrientGroup",
   "Target.Speciation", "TADA.NearbySiteGroups", "numres", "TADA.SingleOrgDupGroupID",
-  "TADA.MeasureQualifierCode.Flag", "MeasureQualifierCode", "TADA.MeasureQualifierCode", "value", "Flag_Column",
+  "TADA.MeasureQualifierCode.Flag", "MeasureQualifierCode", "TADA.MeasureQualifierCode.Define", "value", "Flag_Column",
   "Data_NCTCShepherdstown_HUC12", "ActivityStartDateTime", "TADA.MultipleOrgDupGroupID",
   "TADA.WQXVal.Flag"
 ))
@@ -591,7 +591,7 @@ TADA_OrderCols <- function(.data) {
     "TADA.ResultMeasureValueDataTypes.Flag",
     "TADA.ResultValueAggregation.Flag",
     "TADA.MeasureQualifierCode.Flag",
-    "TADA.MeasureQualifierCode",
+    "TADA.MeasureQualifierCode.Define",
     "TADA.CensoredData.Flag",
     "TADA.CensoredMethod",
     "TADA.NutrientSummation.Flag",

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -1158,6 +1158,8 @@ TADA_CheckRequiredFields <- function(.data) {
     "TADA.ResultMeasureValueDataTypes.Flag",
     "TADA.LatitudeMeasure",
     "TADA.LongitudeMeasure",
+    "TADA.MeasureQualifierCode.Def", 
+    "TADA.MeasureQualifierCode.Flag", 
     "OrganizationFormalName",
     "ActivityTypeCode",
     "ActivityMediaName",

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -50,7 +50,7 @@ utils::globalVariables(c(
   "SummationName", "SummationRank", "SummationFractionNotes", "SummationSpeciationNotes",
   "SummationSpeciationConversionFactor", "SummationNote", "NutrientGroup",
   "Target.Speciation", "TADA.NearbySiteGroups", "numres", "TADA.SingleOrgDupGroupID",
-  "TADA.MeasureQualifierCode.Flag", "MeasureQualifierCode", "TADA.MeasureQualifierCode" "value", "Flag_Column",
+  "TADA.MeasureQualifierCode.Flag", "MeasureQualifierCode", "TADA.MeasureQualifierCode", "value", "Flag_Column",
   "Data_NCTCShepherdstown_HUC12", "ActivityStartDateTime", "TADA.MultipleOrgDupGroupID",
   "TADA.WQXVal.Flag"
 ))
@@ -211,19 +211,18 @@ TADA_AutoClean <- function(.data) {
   
   # Create TADA.MeasureQualifierCode by concatenating MeasureQualifierCode with description from MeasureQualifierCodeRef.
   mqc.ref <-  utils::read.csv(system.file("extdata", "WQXMeasureQualifierCodeRef.csv", package = "TADA")) %>%
-    select(Code, Description) %>%
-    group_by(Code) %>%
-    mutate(Concat = paste(Code, "-", Description, collapse  ="")) %>%
-    select(Code, Concat) %>%
-    rename(MeasureQualifierCode = Code)
+    dplyr::select(Code, Description) %>%
+    dplyr::group_by(Code) %>%
+    dplyr::mutate(Concat = paste(Code, "-", Description, collapse  ="")) %>%
+    dplyr::select(Code, Concat) %>%
+    dplyr::rename(MeasureQualifierCode = Code)
   
   mqc.TADA <- .data %>%
-    mutate(MeasureQualifierCode = str_split(MeasureQualifierCode, ";")) %>%
-    unnest(MeasureQualifierCode) %>%
-    merge(mqc.try) %>%
-    group_by(ResultIdentifier) %>%
-    summarize(TADA.MeasureQualifierCode = paste(Concat, collapse = "; "))
-  
+    dplyr::mutate(MeasureQualifierCode = str_split(MeasureQualifierCode, ";")) %>%
+    tidyr::unnest(MeasureQualifierCode) %>%
+    merge(mqc.ref) %>%
+    dplyr::group_by(ResultIdentifier) %>%
+    dplyr::summarize(TADA.MeasureQualifierCode = paste(Concat, collapse = "; "))
   
   .data$TADA.MeasureQualifierCode <- mqc.TADA$TADA.MeasureQualifierCode[match(.data$ResultIdentifier, mqc.TADA$ResultIdentifier)]
   

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -209,25 +209,6 @@ TADA_AutoClean <- function(.data) {
   # Identify QC data
   .data <- TADA_FindQCActivities(.data, clean = FALSE, flaggedonly = FALSE)
   
-  # Create TADA.MeasureQualifierCode by concatenating MeasureQualifierCode with description from MeasureQualifierCodeRef.
-  mqc.ref <-  utils::read.csv(system.file("extdata", "WQXMeasureQualifierCodeRef.csv", package = "TADA")) %>%
-    dplyr::select(Code, Description) %>%
-    dplyr::group_by(Code) %>%
-    dplyr::mutate(Concat = paste(Code, "-", Description, collapse  ="")) %>%
-    dplyr::select(Code, Concat) %>%
-    dplyr::rename(MeasureQualifierCode = Code)
-  
-  mqc.TADA <- .data %>%
-    dplyr::mutate(MeasureQualifierCode = str_split(MeasureQualifierCode, ";")) %>%
-    tidyr::unnest(MeasureQualifierCode) %>%
-    merge(mqc.ref) %>%
-    dplyr::group_by(ResultIdentifier) %>%
-    dplyr::summarize(TADA.MeasureQualifierCode = paste(Concat, collapse = "; "))
-  
-  .data$TADA.MeasureQualifierCode <- mqc.TADA$TADA.MeasureQualifierCode[match(.data$ResultIdentifier, mqc.TADA$ResultIdentifier)]
-  
-  rm(mqc.ref, mqc.TADA)
-  
   # change latitude and longitude measures to class numeric
   .data$TADA.LatitudeMeasure <- as.numeric(.data$LatitudeMeasure)
   .data$TADA.LongitudeMeasure <- as.numeric(.data$LongitudeMeasure)

--- a/inst/extdata/WQXMeasureQualifierCodeRef.csv
+++ b/inst/extdata/WQXMeasureQualifierCodeRef.csv
@@ -1,233 +1,245 @@
-Domain,Unique.Identifier,Code,Description,Last.Change.Date,TADA.MeasureQualifierCode.Flag
-Result Measure Qualifier(MeasureQualifierCode),307,$,Incorrect sample container,4/12/2017 15:14,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1160,&,biological organism established as dominant,8/16/2021 11:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),1161,(,blank greater than the sample-specific Critical Level,8/16/2021 11:03,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1162,),sample specific MDC (Minimum Detectable Change) above contractual MDC,8/16/2021 11:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),308,*,Sample was warm when received,4/12/2017 15:14,Pass
-Result Measure Qualifier(MeasureQualifierCode),814,+,Recovery is outside acceptance limits and/or RPD exceeds control limits,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1185,2-5B,Result was between 2-5 times the blank concentration - set to Detected Not Quantified,5/31/2023 16:54,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),1186,<2B,Result was <2 times the blank concentration - set to Not Detected,5/31/2023 16:54,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),1100,=,Equal To,9/9/2020 11:38,Pass
-Result Measure Qualifier(MeasureQualifierCode),55,A,Compound not analyzed,8/22/2013 13:44,Pass
-Result Measure Qualifier(MeasureQualifierCode),1171,AC,sample variability described see activity comment for more details,8/16/2021 11:08,Pass
-Result Measure Qualifier(MeasureQualifierCode),206,AL,Aldol condensation present. Analyte may not be present.,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),122,ALK,"Estimate, Alkylated PAH Sum",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),123,ALT,Alternate Method,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),822,AP,The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample. And serial dilution acceptance criteria not met,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),1121,AR,counts outside acceptable range,8/16/2021 11:05,Suspect
-Result Measure Qualifier(MeasureQualifierCode),5,B,"Detection in blank, Analyte found in sample and associated blank",4/24/2008 8:28,Pass
-Result Measure Qualifier(MeasureQualifierCode),124,BAC,"Correction Factor, background",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),125,BQL,Below Quantitation Limit,7/6/2016 16:09,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),126,BRL,Below Reporting Limit,7/6/2016 16:09,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),821,BS,Compound was found in the blank and sample,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1182,BSR,Lab spiked blank acceptance criteria not met,11/12/2021 13:38,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1183,BT,Detection in Trip Blank,11/12/2021 13:38,Suspect
-Result Measure Qualifier(MeasureQualifierCode),223,BVER,Continuing calibration blank criteria was not met,9/28/2016 13:08,Suspect
-Result Measure Qualifier(MeasureQualifierCode),58,C,Presence of compound may be due to contamination of sample during laboratory processing,8/22/2013 13:44,Suspect
-Result Measure Qualifier(MeasureQualifierCode),127,C25,Dual Column result difference >25%,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),128,CAJ,"Correction Factor, lab",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),129,CAN,"No Result Reported, analysis canceled",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),130,CBC,"No Result Reported, cannot be calculated",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1122,CBG,"CC B G; Co-eluting congener, analyte found in sample and associated blank, and lock mass interference present",5/21/2021 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),131,CBL,"Correction Factor, blank",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),189,CC,co-eluting congener,6/15/2016 13:28,Pass
-Result Measure Qualifier(MeasureQualifierCode),132,CDI,"Correction Factor, dilution",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),1126,CG,CC G; Co-eluting congener and lock mass interference present,5/21/2021 17:10,Pass
-Result Measure Qualifier(MeasureQualifierCode),1128,CKB,"CC PK B; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and analyte found in sample and associated blank",5/21/2021 17:13,Pass
-Result Measure Qualifier(MeasureQualifierCode),1127,CKBJ,"CC PK B J;Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration), analyte found in sample and associated blank, and the reported result is an estimate (the value is less than the minimum calibration level",5/21/2021 17:12,Pass
-Result Measure Qualifier(MeasureQualifierCode),1129,CKG,"CC PK G; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and lock mass interference present",5/21/2021 17:17,Pass
-Result Measure Qualifier(MeasureQualifierCode),1130,CKJ,"CC PK J; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and the reported result is an estimate (the value is less than the minimum calibration level but greater than the estimated detection limit)",5/21/2021 17:18,Pass
-Result Measure Qualifier(MeasureQualifierCode),133,CLC,"Correction Factor, other",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),207,CNT,Non-acceptable colony counts.,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),134,CON,Value Confirmed,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),1180,CSR,Calibration standard acceptance criteria not met,11/12/2021 13:38,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1131,CUG,"CC U G; Co-eluting congener, the analyte was not detected in the sample at the estimated detection limit and lock mass interference present",5/21/2021 17:18,Pass
-Result Measure Qualifier(MeasureQualifierCode),11,D,"Contract Required Quantitation Limit (CRQL) not met due to sample matrix interference, dilution required.  ",5/14/2009 14:21,Pass
-Result Measure Qualifier(MeasureQualifierCode),1184,D>T,Result dissolved concentration was greater than its total and the absolute difference was greater than or equal to the total MDL - set to Detected Not Quantified,5/31/2023 16:54,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),330,DE,Serial dilution acceptance criteria not met.,8/22/2017 12:37,Suspect
-Result Measure Qualifier(MeasureQualifierCode),135,DEC,Value Decensored -  reconstruct or remove the objectionable values of a measurement set,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),808,DI,Dilution required,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),73,DL,Not Detected: The analyte was not detected at a level >= to the Method Detection Limit for the analysis.,11/25/2013 13:44,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),1168,DOM,count >= 15 percent (dominant),8/16/2021 11:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),1001,DT,Date value on logger was incorrect; Changed to date of sampling event; Date and Time considered suspect.,4/13/2020 7:13,Pass
-Result Measure Qualifier(MeasureQualifierCode),54,E,Concentration of analyte being analyzed exceeded calibration range of instrument.,2/13/2012 18:03,Over-Detect
-Result Measure Qualifier(MeasureQualifierCode),136,ECI,"Estimated Value, Coelution",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),19,EE,Identifies compounds whose concentration exceed the calibration range addition of the instrument for that specific analysis.,8/28/2009 17:04,Over-Detect
-Result Measure Qualifier(MeasureQualifierCode),788,EER,"No Result Reported, entry error; Original value is known to be incorrect due to a data entry error.  The correct value could not be determined. No result value was reported",1/23/2020 14:12,Suspect
-Result Measure Qualifier(MeasureQualifierCode),59,EFAI,Equipment failure,8/22/2013 13:44,Suspect
-Result Measure Qualifier(MeasureQualifierCode),137,EMPC,Estimated Maximum Possible Concentration,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),138,ESD,"Estimated Value, serial dilution difference",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),139,EST,"Estimated Value, outside limit of precision",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),140,EVA,"Estimated Value, multiple Aroclors",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),141,EVAD,"Estimated Value, degradation",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),142,EVID,"Estimated Value, tentatively identified compound",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),60,F,Estimated value: compound failed initial calibration check (CCC) or QC criteria,8/22/2013 13:44,Suspect
-Result Measure Qualifier(MeasureQualifierCode),143,FDB,"Dry Blank, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),144,FDC,"Drift Check, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),145,FDL,"Lab Duplicate, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),53,FEQ,Field Equipment Questionable,1/11/2012 17:15,Suspect
-Result Measure Qualifier(MeasureQualifierCode),209,FFB,Failed. Field blank not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),146,FFD,"Field Duplicate, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),210,FFS,Failed. Field spike not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),211,FFT,Failed. Trip blank not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),829,FH,"Failed high at audit check during deployment. Could include pre, mid or post deployment check.",4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),147,FIS,"Internal Standard, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),830,FL,"Failed low at audit check during deployment. Could include pre, mid or post deployment check.",4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),148,FLA,Field Lab Anomaly,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1060,FLC,"Linearity Check, failed",7/10/2020 12:31,Suspect
-Result Measure Qualifier(MeasureQualifierCode),208,FLD,Failed. Lab duplicate not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),212,FLS,Failed. Lab spike recovery not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),304,FMD,Failed. Matrix Spike Duplicate not acceptable.,11/18/2019 10:00,Suspect
-Result Measure Qualifier(MeasureQualifierCode),213,FMS,Failed. Matrix spike recovery not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),149,FPC,"Performance Check, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1165,FPP,sample field preparation problem,8/16/2021 11:03,Suspect
-Result Measure Qualifier(MeasureQualifierCode),150,FPR,"Ongoing Precision and Recovery, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),151,FQC,"Quality Control, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),152,FRS,"Lab Reference, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),153,FSD,"Lab Spike Duplicate, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),215,FSL,Failed. Spiked lab blank recovery not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),214,FSP,Failed. Surrogate spike recovery not acceptable.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),154,FUB,"Field Tubing Blank, failed",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),191,G,lock mass interference present,6/15/2016 13:28,Suspect
-Result Measure Qualifier(MeasureQualifierCode),815,GR4,"The analyte present in the original sample is greater than 4 times the matrix spike concentration; therefore, control limits are not applicable",4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),74,GT,The listed result is greater than the upper quantitation limit for either the analytical method or the meter used for the measurement. Equivalent to the Legacy STORET Remark Code of L: Actual Value is known to be greater than the value given.,11/25/2013 13:44,Over-Detect
-Result Measure Qualifier(MeasureQualifierCode),155,GXB,"Estimated Value, greater than 10x blank",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),6,H,Holding time exceeded: ,4/24/2008 8:28,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1002,H2,Extraction or preparation was conducted outside of the recognized method holding time.,5/23/2023 9:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1003,H3,Sample was received or analysis requested beyond the recognized method holding time.,5/23/2023 9:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1164,HE,value extrapolated at high end,8/16/2021 11:03,Suspect
-Result Measure Qualifier(MeasureQualifierCode),819,HH,Out High,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),156,HIB,Likely Biased High,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),113,HICC,Initial calibration criteria not met – high,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),157,HIM,High Moisture ,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),23,HLBL,high labeled compound recovery in sample,2/19/2021 8:38,Pass
-Result Measure Qualifier(MeasureQualifierCode),120,HMSD,Matrix spike duplicate acceptance criteria not met – high,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),24,HMSR,"high matrix spike recovery, potential high bias",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),25,HNRO,"high native analyte recovery in OPR (or LCS), potential high bias",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),827,HQ,High Quality control measures,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),158,HTH,Hard to Homogenize,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),27,HVER,"high calibration verification standard recovery, estimated value",5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),61,I,Estimated value; compound failed initial calibration value,8/22/2013 13:44,Suspect
-Result Measure Qualifier(MeasureQualifierCode),159,ICA,Incorrect Initial Calibration Associated with Sample,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),647,IDL,"Instrument Detection Limit, less than",2/21/2019 10:42,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),216,INT,Interference suspected. Analyte may not be present.,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),224,IQCOL,"ICV,CCV,ICB,CCB, ISA, ISB, CRI, CRA, DLCK or MRL standard: Instrument related QC is outside acceptance limits",10/27/2016 7:54,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1170,IS,instrument sensitivity problem,8/16/2021 11:08,Suspect
-Result Measure Qualifier(MeasureQualifierCode),118,ISAC,Internal standard acceptance criteria not met,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),160,ISP,Improper Sample Preservation,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1181,ISR**,Internal Standard acceptance criteria not met***retired***use ISAC,3/9/2022 10:35,Suspect
-Result Measure Qualifier(MeasureQualifierCode),49,ITNA,Incubation time not attained,2/2/2011 17:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),48,ITNM,Incubation temperature not maintained,2/2/2011 17:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1,J,Estimated: The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample.,8/11/2006 23:50,Pass
-Result Measure Qualifier(MeasureQualifierCode),7,J+,Estimated: The analyte was positively identified and the associated numerical value... +++.,5/7/2009 13:08,Pass
-Result Measure Qualifier(MeasureQualifierCode),57,J-,"The analyte was positively identified; the associated numerical value is the approximate concentration of the analyte in the sample, and may have a potential negative bias.",2/19/2016 8:34,Pass
-Result Measure Qualifier(MeasureQualifierCode),68,J-1,Estimated value. A full explanation is presented in the narrative.,9/28/2023 14:48,Not Reviewed
-Result Measure Qualifier(MeasureQualifierCode),64,J-R,Approximate value result is below the reporting level but greater than the method detection limit,8/23/2021 11:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),161,JCN,"Sample Container Damaged, no sample lost",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),162,JCW,"Sample Container Damaged, sample lost",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),66,K,Value below the detection Limit.  For BOD: depletion is less than 1.0,8/22/2013 13:44,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),163,KCF,"Known Contamination, field",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1061,KCX,"Known Contamination, unknown",7/10/2020 12:31,Suspect
-Result Measure Qualifier(MeasureQualifierCode),18,KK,True bacterial concentration is assumed to be less than the reported value. ,8/28/2009 17:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),51,L,Lowest available reporting limit for the analytical method used.,12/2/2011 16:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),165,LAC,"No Result Reported, lab accident",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),222,LBF,"Lab Failed, sample not analyzed",8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),809,LCS,LCS or LCSD,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),1166,LF,count < 0.5 percent,8/16/2021 11:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),114,LICC,Initial calibration criteria not met – low,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),217,LIS,Lab internal standard(s) added to sample.,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),20,LL,True bacterial concentration is assumed to be greater than the reported value. ,8/28/2009 17:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),28,LLBL,low labeled compound recovery in sample,2/19/2021 0:00,Pass
-Result Measure Qualifier(MeasureQualifierCode),218,LLS,Value less than lower quality control standard.,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),121,LMSD,Matrix spike duplicate acceptance criteria not met – low,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),30,LMSR,"low matrix spike recovery, potential low bias",5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),31,LNRO,"low native analyte recovery in OPR (or LCS), potential low bias",5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),1173,LO,laboratory Control Sample (LCS) recovery outside of accept range,8/16/2021 11:09,Suspect
-Result Measure Qualifier(MeasureQualifierCode),166,LOB,Likely Biased Low,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),32,LOPR,"low OPR (or LCS) recovery, potential low bias",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),828,LQ,Low Quality control measures,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),810,LR,Operating Range,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),117,LSSR,Surrogate standard acceptance criteria not met – low,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),817,LT,Less Than,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),834,LTGTE,Result is less than the MQL but greater than or equal to the MDL,4/10/2020 18:07,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),33,LVER,"low calibration verification standard recovery, potential low bias",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),168,M6F,More Than 6 Flags Applied,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),813,MDL,Method Detection Level,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1040,MI,Matrix Interference,4/24/2020 20:50,Suspect
-Result Measure Qualifier(MeasureQualifierCode),816,MSD,MS and/or MSD,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),119,MSR,Matrix spike acceptance criteria not met,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),67,N,Presumptive evidence of a nontarget compound,8/22/2013 13:44,Pass
-Result Measure Qualifier(MeasureQualifierCode),290,NA,Not Applicable,11/14/2016 14:52,Not Reviewed
-Result Measure Qualifier(MeasureQualifierCode),169,NAI,"No Result Reported, interference",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),823,NFNS,Comparison of nutrient fractions (e.g. filtered > unfiltered) or nutrient species (e.g. PO4 > TP) are not consistent,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),170,NHS,Non-homogenous sample,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),36,NLBL,"no labeled compound recovery in sample, rejected",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),37,NLRO,"no labeled compound recovery in OPR (or LCS), rejected",5/19/2010 11:24,Suspect
-Result Measure Qualifier(MeasureQualifierCode),190,NN,authentic recovery is not within method/contract control limits,6/15/2016 13:28,Suspect
-Result Measure Qualifier(MeasureQualifierCode),820,NPNF,Normal protocol not followed,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1163,NRB,negative result may indicate potential negative bias,8/16/2021 11:03,Suspect
-Result Measure Qualifier(MeasureQualifierCode),115,NRO,Control sample acceptance criteria not met,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),291,NRP,No Result Possible,11/14/2016 14:52,Suspect
-Result Measure Qualifier(MeasureQualifierCode),171,NRR,"No Result Reported, other",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),791,NRS,Non Representative Sample; Sample does not represent the environmental conditions.,1/23/2020 14:12,Suspect
-Result Measure Qualifier(MeasureQualifierCode),172,NSQ,"No Result Reported, insufficient quantity of sample",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),818,NW,Not Within,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),1140,O,result determined by alternate method,8/11/2021 16:34,Pass
-Result Measure Qualifier(MeasureQualifierCode),173,OA3,"Outlier, across stations",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),174,OS3,"Outlier, single station",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),175,OTHER,Other,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),220,OUT,Result value is defined as an outlier by data owner,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),1080,P,PCDE interference,8/5/2020 9:55,Suspect
-Result Measure Qualifier(MeasureQualifierCode),826,PB,Continuous probe biased,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),1133,PK,Peak deteced but did not meet quantification criteria (result reported represents the estimated maximum possible concentration),5/21/2021 0:00,Pass
-Result Measure Qualifier(MeasureQualifierCode),176,PNQ,No Quantifiable Result Reported,3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1132,PP,sample preparation problem,8/16/2021 11:05,Suspect
-Result Measure Qualifier(MeasureQualifierCode),177,PPD,"Spiked Blank Duplicate, failed",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),1101,PQL,PQL or LQL,9/9/2020 11:46,Pass
-Result Measure Qualifier(MeasureQualifierCode),219,PRE,Presumptive evidence that analyte is present.,8/30/2016 16:56,Pass
-Result Measure Qualifier(MeasureQualifierCode),77,Q,The result did not pass the lab quality checks and there was an insufficient amount of the sample for re-analysis.,11/25/2013 13:44,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1020,QC,Quality Control problems,4/22/2020 8:09,Suspect
-Result Measure Qualifier(MeasureQualifierCode),178,QCI,Quality Control incomplete,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),2,R,Rejected: The sample results are unusable due to the quality of the data generated because certain criteria were not met. The analyte may or may not be present in the sample. ,8/11/2006 23:50,Suspect
-Result Measure Qualifier(MeasureQualifierCode),825,RA,Results fall outside the normal limits of variability and do not meet Data Quality Objectives. Reanalyses were performed with consistent results. All QA ,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1120,RC,See result comment,8/12/2021 21:36,Pass
-Result Measure Qualifier(MeasureQualifierCode),179,REX,Re-Prepared,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),180,RIN,Re-Analyzed,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),181,RLRS,"Reporting limit raised, low total solids",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),42,RMAX,result is a maximum value,5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),43,RNAF,result not affected by noted QC issue,5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),45,RNON,result reported as non-detect due to blank contamination,5/19/2010 11:24,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),1169,RP,value reported is preferred,8/16/2021 11:08,Pass
-Result Measure Qualifier(MeasureQualifierCode),46,RPDX,"RPD is MS/MSD pair exceeds criterion, estimated value",5/19/2010 11:24,Pass
-Result Measure Qualifier(MeasureQualifierCode),203,RPO,% RPD outside of acceptable limits,7/6/2016 16:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),811,RR,Lab reported a result value,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),824,RV,Results are within precision limits and are analytically equal.,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),812,RVB,Result Value Between,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),1134,S2,Shipping time exceeded two day limit,6/1/2021 13:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),182,SBB,"Estimated Value, less than blank",3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),183,SCA,"Suspected Contamination, lab analysis",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),184,SCF,"Suspected Contamination, field",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),185,SCP,"Suspected Contamination, lab preparation",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),186,SCX,"Suspected Contamination, unknown",3/16/2016 13:04,Suspect
-Result Measure Qualifier(MeasureQualifierCode),226,SD%EL,MS/MSD RPD exceeds control limits,10/27/2016 7:54,Suspect
-Result Measure Qualifier(MeasureQualifierCode),225,SDROL,MS and/or MSD Recovery is outside acceptance limits,10/27/2016 7:54,Suspect
-Result Measure Qualifier(MeasureQualifierCode),187,SLB,Spike level low compared to background,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),757,SM,same method (USGS),8/18/2020 13:51,Pass
-Result Measure Qualifier(MeasureQualifierCode),833,SS,Sample size difference,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),116,SSR,Surrogate standard acceptance criteria not met,4/9/2015 9:10,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1000,SSRV,Surrogate or spike recovery value associated with sample analyte or analytes,5/23/2022 8:46,Pass
-Result Measure Qualifier(MeasureQualifierCode),221,SUS,Result value is defined as suspect by data owner. (HV) High variability: questionable precision and accuracy,8/30/2016 16:56,Suspect
-Result Measure Qualifier(MeasureQualifierCode),108,T,Hardness by Calculation Method - Standard Methods 2340B - 19th Ed ,9/3/2014 0:00,Pass
-Result Measure Qualifier(MeasureQualifierCode),707,TMLF,Time missing in logger file.,7/30/2019 7:36,Pass
-Result Measure Qualifier(MeasureQualifierCode),112,TOC,Temperature outside of criteria,4/9/2015 9:10,Pass
-Result Measure Qualifier(MeasureQualifierCode),192,TT,analyte recalculated against alternate labeled compound(s),6/15/2016 13:28,Pass
-Result Measure Qualifier(MeasureQualifierCode),3,U,"Not Detected: The analyte was analyzed for, but was not detected at a level greater than or equal to the level of the adjusted Contract Required Quantitation Limit (CRQL) for sample and method. ",8/11/2006 23:50,Non-Detect
-Result Measure Qualifier(MeasureQualifierCode),831,UDL,Lab's detection limit is not known/available for validation or comparison to the result.,4/10/2020 18:07,Suspect
-Result Measure Qualifier(MeasureQualifierCode),832,UDQ,Lab's detection limit not known/available for comparison to the result; however with parameter specific evaluation determined to be quantified.,4/10/2020 18:07,Pass
-Result Measure Qualifier(MeasureQualifierCode),188,UNC,Value Not Confirmed,3/16/2016 13:04,Pass
-Result Measure Qualifier(MeasureQualifierCode),749,V,Surrogate recoveries out of range,12/16/2019 12:53,Suspect
-Result Measure Qualifier(MeasureQualifierCode),1167,VS,compound identified verified by 2nd method,8/16/2021 11:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),758,VVRR,Value verified by rerun,8/18/2020 13:54,Pass
-Result Measure Qualifier(MeasureQualifierCode),1172,VVRR2,"value verified by rerun, 2nd method",8/16/2021 11:08,Pass
-Result Measure Qualifier(MeasureQualifierCode),26,ZZ,"Blank-corrected data were indicated by the ""Z"" qualifier code. The laboratory reported the concentration of analyte to the nearest unit. These data were qualified as blank-corrected and as undetected when the blank correction resulted in a concentration below the DL.",8/31/2023 18:03,Pass
-Result Measure Qualifier(MeasureQualifierCode),311,^,Yield outside of contractual acceptable range (USGS),4/12/2017 15:14,Suspect
+"Domain","Unique.Identifier","Code","Description","Last.Change.Date","TADA.MeasureQualifierCode.Flag"
+"Result Measure Qualifier(MeasureQualifierCode)",307,"$","Incorrect sample container","4/12/2017 3:14:21 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1160,"&","biological organism established as dominant","8/16/2021 11:03:37 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1161,"(","blank greater than the sample-specific Critical Level","8/16/2021 11:03:37 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1162,")","sample specific MDC (Minimum Detectable Change) above contractual MDC","8/16/2021 11:03:38 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",308,"*","Sample was warm when received","4/12/2017 3:14:21 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",814,"+","Recovery is outside acceptance limits and/or RPD exceeds control limits","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1185,"2-5B","Result was between 2-5 times the blank concentration - set to Detected Not Quantified","5/31/2023 4:54:48 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",1186,"<2B","Result was <2 times the blank concentration - set to Not Detected","5/31/2023 4:54:48 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",1100,"=","Equal To","9/9/2020 11:38:33 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",55,"A","Compound not analyzed","8/22/2013 1:44:00 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1171,"AC","sample variability described see activity comment for more details","8/16/2021 11:08:55 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",206,"AL","Aldol condensation present. Analyte may not be present.","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",122,"ALK","Estimate, Alkylated PAH Sum","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",123,"ALT","Alternate Method","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",822,"AP","The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample. And serial dilution acceptance criteria not met","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1121,"AR","counts outside acceptable range","8/16/2021 11:05:27 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",5,"B","Detection in blank, Analyte found in sample and associated blank","4/24/2008 8:28:30 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",124,"BAC","Correction Factor, background","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",125,"BQL","Below Quantitation Limit","7/6/2016 4:09:14 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",126,"BRL","Below Reporting Limit","7/6/2016 4:09:17 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",821,"BS","Compound was found in the blank and sample","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1182,"BSR","Lab spiked blank acceptance criteria not met","11/12/2021 1:38:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1183,"BT","Detection in Trip Blank","11/12/2021 1:38:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",223,"BVER","Continuing calibration blank criteria was not met","9/28/2016 1:08:07 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",58,"C","Presence of compound may be due to contamination of sample during laboratory processing","8/22/2013 1:44:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",127,"C25","Dual Column result difference >25%","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",128,"CAJ","Correction Factor, lab","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",129,"CAN","No Result Reported, analysis canceled","3/16/2016 1:04:24 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",130,"CBC","No Result Reported, cannot be calculated","3/16/2016 1:04:24 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1122,"CBG","CC B G; Co-eluting congener, analyte found in sample and associated blank, and lock mass interference present","5/21/2021 4:56:03 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",131,"CBL","Correction Factor, blank","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",189,"CC","co-eluting congener","6/15/2016 1:28:59 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",132,"CDI","Correction Factor, dilution","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1126,"CG","CC G; Co-eluting congener and lock mass interference present","5/21/2021 5:10:50 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1128,"CKB","CC PK B; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and analyte found in sample and associated blank","5/21/2021 5:13:41 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1127,"CKBJ","CC PK B J;Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration), analyte found in sample and associated blank, and the reported result is an estimate (the value is less than the minimum calibration level","5/21/2021 5:12:53 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1129,"CKG","CC PK G; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and lock mass interference present","5/21/2021 5:17:08 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1130,"CKJ","CC PK J; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and the reported result is an estimate (the value is less than the minimum calibration level but greater than the estimated detection limit)","5/21/2021 5:18:08 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",133,"CLC","Correction Factor, other","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",207,"CNT","Non-acceptable colony counts.","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",134,"CON","Value Confirmed","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1180,"CSR","Calibration standard acceptance criteria not met","11/12/2021 1:38:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1131,"CUG","CC U G; Co-eluting congener, the analyte was not detected in the sample at the estimated detection limit and lock mass interference present","5/21/2021 5:18:42 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",11,"D","Contract Required Quantitation Limit (CRQL) not met due to sample matrix interference, dilution required.  ","5/14/2009 2:21:45 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1184,"D>T","Result dissolved concentration was greater than its total and the absolute difference was greater than or equal to the total MDL - set to Detected Not Quantified","5/31/2023 4:54:47 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",330,"DE","Serial dilution acceptance criteria not met.","8/22/2017 12:37:58 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",135,"DEC","Value Decensored -  reconstruct or remove the objectionable values of a measurement set","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",808,"DI","Dilution required","4/10/2020 6:07:21 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",73,"DL","Not Detected: The analyte was not detected at a level >= to the Method Detection Limit for the analysis.","11/25/2013 1:44:00 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",1168,"DOM","count >= 15 percent (dominant)","8/16/2021 11:03:38 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1001,"DT","Date value on logger was incorrect; Changed to date of sampling event; Date and Time considered suspect.","4/13/2020 7:13:06 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",54,"E","Concentration of analyte being analyzed exceeded calibration range of instrument.","2/13/2012 6:03:18 PM","Over-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",136,"ECI","Estimated Value, Coelution","3/16/2016 1:04:24 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",19,"EE","Identifies compounds whose concentration exceed the calibration range addition of the instrument for that specific analysis.","8/28/2009 5:04:35 PM","Over-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",788,"EER","No Result Reported, entry error; Original value is known to be incorrect due to a data entry error.  The correct value could not be determined. No result value was reported","1/23/2020 2:12:06 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",59,"EFAI","Equipment failure","8/22/2013 1:44:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",137,"EMPC","Estimated Maximum Possible Concentration","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",138,"ESD","Estimated Value, serial dilution difference","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",139,"EST","Estimated Value, outside limit of precision","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",140,"EVA","Estimated Value, multiple Aroclors","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",141,"EVAD","Estimated Value, degradation","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",142,"EVID","Estimated Value, tentatively identified compound","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",60,"F","Estimated value: compound failed initial calibration check (CCC) or QC criteria","8/22/2013 1:44:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",143,"FDB","Dry Blank, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",144,"FDC","Drift Check, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",145,"FDL","Lab Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",53,"FEQ","Field Equipment Questionable","1/11/2012 5:15:03 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",209,"FFB","Failed. Field blank not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",146,"FFD","Field Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",210,"FFS","Failed. Field spike not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",211,"FFT","Failed. Trip blank not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",829,"FH","Failed high at audit check during deployment. Could include pre, mid or post deployment check.","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",147,"FIS","Internal Standard, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",830,"FL","Failed low at audit check during deployment. Could include pre, mid or post deployment check.","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",148,"FLA","Field Lab Anomaly","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1060,"FLC","Linearity Check, failed","7/10/2020 12:31:13 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",208,"FLD","Failed. Lab duplicate not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",212,"FLS","Failed. Lab spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",304,"FMD","Failed. Matrix Spike Duplicate not acceptable.","11/18/2019 10:00:52 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",213,"FMS","Failed. Matrix spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",149,"FPC","Performance Check, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1165,"FPP","sample field preparation problem","8/16/2021 11:03:38 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",150,"FPR","Ongoing Precision and Recovery, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",151,"FQC","Quality Control, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",152,"FRS","Lab Reference, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",153,"FSD","Lab Spike Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",215,"FSL","Failed. Spiked lab blank recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",214,"FSP","Failed. Surrogate spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",154,"FUB","Field Tubing Blank, failed","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",191,"G","lock mass interference present","6/15/2016 1:28:59 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",815,"GR4","The analyte present in the original sample is greater than 4 times the matrix spike concentration; therefore, control limits are not applicable","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",74,"GT","The listed result is greater than the upper quantitation limit for either the analytical method or the meter used for the measurement. Equivalent to the Legacy STORET Remark Code of L: Actual Value is known to be greater than the value given.","11/25/2013 1:44:00 PM","Over-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",155,"GXB","Estimated Value, greater than 10x blank","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",6,"H","Holding time exceeded: ","4/24/2008 8:28:31 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1002,"H2","Extraction or preparation was conducted outside of the recognized method holding time.","5/23/2023 9:56:04 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1003,"H3","Sample was received or analysis requested beyond the recognized method holding time.","5/23/2023 9:56:04 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1164,"HE","value extrapolated at high end","8/16/2021 11:03:38 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",819,"HH","Out High","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",156,"HIB","Likely Biased High","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",113,"HICC","Initial calibration criteria not met – high","4/9/2015 9:10:23 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",157,"HIM","High Moisture ","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",23,"HLBL","high labeled compound recovery in sample","2/19/2021 8:38:02 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",120,"HMSD","Matrix spike duplicate acceptance criteria not met – high","4/9/2015 9:10:25 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",24,"HMSR","high matrix spike recovery, potential high bias","5/19/2010 11:24:46 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",25,"HNRO","high native analyte recovery in OPR (or LCS), potential high bias","5/19/2010 11:24:46 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",827,"HQ","High Quality control measures","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",158,"HTH","Hard to Homogenize","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",27,"HVER","high calibration verification standard recovery, estimated value","5/19/2010 11:24:47 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",61,"I","Estimated value; compound failed initial calibration value","8/22/2013 1:44:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",159,"ICA","Incorrect Initial Calibration Associated with Sample","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",647,"IDL","Instrument Detection Limit, less than","2/21/2019 10:42:45 AM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",216,"INT","Interference suspected. Analyte may not be present.","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",224,"IQCOL","ICV,CCV,ICB,CCB, ISA, ISB, CRI, CRA, DLCK or MRL standard: Instrument related QC is outside acceptance limits","10/27/2016 7:54:50 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1170,"IS","instrument sensitivity problem","8/16/2021 11:08:55 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",118,"ISAC","Internal standard acceptance criteria not met","4/9/2015 9:10:25 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",160,"ISP","Improper Sample Preservation","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1181,"ISR**","Internal Standard acceptance criteria not met***retired***use ISAC","3/9/2022 10:35:35 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",49,"ITNA","Incubation time not attained","2/2/2011 5:07:31 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",48,"ITNM","Incubation temperature not maintained","2/2/2011 5:07:30 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1,"J","Estimated: The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample.","8/11/2006 11:50:00 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",7,"J+","Estimated: The analyte was positively identified and the associated numerical value... +++.","5/7/2009 1:08:20 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",57,"J-","The analyte was positively identified; the associated numerical value is the approximate concentration of the analyte in the sample, and may have a potential negative bias.","2/19/2016 8:34:06 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",68,"J-1","Estimated value. A full explanation is presented in the narrative.","9/28/2023 2:48:59 PM","Not Reviewed"
+"Result Measure Qualifier(MeasureQualifierCode)",64,"J-R","Approximate value result is below the reporting level but greater than the method detection limit","8/23/2021 11:04:25 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",161,"JCN","Sample Container Damaged, no sample lost","3/16/2016 1:04:25 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",162,"JCW","Sample Container Damaged, sample lost","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",66,"K","Value below the detection Limit.  For BOD: depletion is less than 1.0","8/22/2013 1:44:00 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",163,"KCF","Known Contamination, field","3/16/2016 1:04:25 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1061,"KCX","Known Contamination, unknown","7/10/2020 12:31:13 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",18,"KK","True bacterial concentration is assumed to be less than the reported value. ","8/28/2009 5:04:14 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",51,"L","Lowest available reporting limit for the analytical method used.","12/2/2011 4:24:36 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",165,"LAC","No Result Reported, lab accident","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",222,"LBF","Lab Failed, sample not analyzed","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",809,"LCS","LCS or LCSD","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1166,"LF","count < 0.5 percent","8/16/2021 11:03:38 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",114,"LICC","Initial calibration criteria not met – low","4/9/2015 9:10:23 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",217,"LIS","Lab internal standard(s) added to sample.","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",20,"LL","True bacterial concentration is assumed to be greater than the reported value. ","8/28/2009 5:04:50 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",28,"LLBL","low labeled compound recovery in sample","2/19/2021 12:00:00 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",218,"LLS","Value less than lower quality control standard.","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",121,"LMSD","Matrix spike duplicate acceptance criteria not met – low","4/9/2015 9:10:26 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",30,"LMSR","low matrix spike recovery, potential low bias","5/19/2010 11:24:47 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",31,"LNRO","low native analyte recovery in OPR (or LCS), potential low bias","5/19/2010 11:24:47 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1173,"LO","laboratory Control Sample (LCS) recovery outside of accept range","8/16/2021 11:09:58 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",166,"LOB","Likely Biased Low","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",32,"LOPR","low OPR (or LCS) recovery, potential low bias","5/19/2010 11:24:47 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",828,"LQ","Low Quality control measures","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",810,"LR","Operating Range","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",117,"LSSR","Surrogate standard acceptance criteria not met – low","4/9/2015 9:10:24 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",817,"LT","Less Than","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",834,"LTGTE","Result is less than the MQL but greater than or equal to the MDL","4/10/2020 6:07:23 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",33,"LVER","low calibration verification standard recovery, potential low bias","5/19/2010 11:24:47 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",168,"M6F","More Than 6 Flags Applied","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",813,"MDL","Method Detection Level","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1040,"MI","Matrix Interference","4/24/2020 8:50:16 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",816,"MSD","MS and/or MSD","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",119,"MSR","Matrix spike acceptance criteria not met","4/9/2015 9:10:25 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",67,"N","Presumptive evidence of a nontarget compound","8/22/2013 1:44:00 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",290,NA,"Not Applicable","11/14/2016 2:52:56 PM","Not Reviewed"
+"Result Measure Qualifier(MeasureQualifierCode)",169,"NAI","No Result Reported, interference","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",823,"NFNS","Comparison of nutrient fractions (e.g. filtered > unfiltered) or nutrient species (e.g. PO4 > TP) are not consistent","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",170,"NHS","Non-homogenous sample","3/16/2016 1:04:26 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",36,"NLBL","no labeled compound recovery in sample, rejected","5/19/2010 11:24:47 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",37,"NLRO","no labeled compound recovery in OPR (or LCS), rejected","5/19/2010 11:24:47 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",190,"NN","authentic recovery is not within method/contract control limits","6/15/2016 1:28:59 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",820,"NPNF","Normal protocol not followed","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1163,"NRB","negative result may indicate potential negative bias","8/16/2021 11:03:38 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",115,"NRO","Control sample acceptance criteria not met","4/9/2015 9:10:24 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",291,"NRP","No Result Possible","11/14/2016 2:52:56 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",171,"NRR","No Result Reported, other","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",791,"NRS","Non Representative Sample; Sample does not represent the environmental conditions.","1/23/2020 2:12:07 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",172,"NSQ","No Result Reported, insufficient quantity of sample","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",818,"NW","Not Within","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1140,"O","result determined by alternate method","8/11/2021 4:34:03 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",173,"OA3","Outlier, across stations","3/16/2016 1:04:26 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",174,"OS3","Outlier, single station","3/16/2016 1:04:26 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",175,"OTHER","Other","3/16/2016 1:04:26 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",220,"OUT","Result value is defined as an outlier by data owner","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1080,"P","PCDE interference","8/5/2020 9:55:33 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",826,"PB","Continuous probe biased","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1133,"PK","Peak deteced but did not meet quantification criteria (result reported represents the estimated maximum possible concentration)","5/21/2021 12:00:00 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",176,"PNQ","No Quantifiable Result Reported","3/16/2016 1:04:26 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1132,"PP","sample preparation problem","8/16/2021 11:05:27 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",177,"PPD","Spiked Blank Duplicate, failed","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1101,"PQL","PQL or LQL","9/9/2020 11:46:05 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",219,"PRE","Presumptive evidence that analyte is present.","8/30/2016 4:56:40 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",77,"Q","The result did not pass the lab quality checks and there was an insufficient amount of the sample for re-analysis.","11/25/2013 1:44:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1020,"QC","Quality Control problems","4/22/2020 8:09:48 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",178,"QCI","Quality Control incomplete","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",2,"R","Rejected: The sample results are unusable due to the quality of the data generated because certain criteria were not met. The analyte may or may not be present in the sample. ","8/11/2006 11:50:00 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",825,"RA","Results fall outside the normal limits of variability and do not meet Data Quality Objectives. Reanalyses were performed with consistent results. All QA ","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1120,"RC","See result comment","8/12/2021 9:36:56 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",179,"REX","Re-Prepared","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",180,"RIN","Re-Analyzed","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",181,"RLRS","Reporting limit raised, low total solids","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",42,"RMAX","result is a maximum value","5/19/2010 11:24:48 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",43,"RNAF","result not affected by noted QC issue","5/19/2010 11:24:48 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",45,"RNON","result reported as non-detect due to blank contamination","5/19/2010 11:24:48 AM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",1169,"RP","value reported is preferred","8/16/2021 11:08:54 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",46,"RPDX","RPD is MS/MSD pair exceeds criterion, estimated value","5/19/2010 11:24:48 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",203,"RPO","% RPD outside of acceptable limits","7/6/2016 4:04:47 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",811,"RR","Lab reported a result value","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",824,"RV","Results are within precision limits and are analytically equal.","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",812,"RVB","Result Value Between","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1134,"S2","Shipping time exceeded two day limit","6/1/2021 1:07:19 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",182,"SBB","Estimated Value, less than blank","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",183,"SCA","Suspected Contamination, lab analysis","3/16/2016 1:04:27 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",184,"SCF","Suspected Contamination, field","3/16/2016 1:04:27 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",185,"SCP","Suspected Contamination, lab preparation","3/16/2016 1:04:27 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",186,"SCX","Suspected Contamination, unknown","3/16/2016 1:04:27 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",226,"SD%EL","MS/MSD RPD exceeds control limits","10/27/2016 7:54:50 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",225,"SDROL","MS and/or MSD Recovery is outside acceptance limits","10/27/2016 7:54:50 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",187,"SLB","Spike level low compared to background","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",757,"SM","same method (USGS)","8/18/2020 1:51:06 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",833,"SS","Sample size difference","4/10/2020 6:07:23 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",116,"SSR","Surrogate standard acceptance criteria not met","4/9/2015 9:10:24 AM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1000,"SSRV","Surrogate or spike recovery value associated with sample analyte or analytes","5/23/2022 8:46:36 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",221,"SUS","Result value is defined as suspect by data owner. (HV) High variability: questionable precision and accuracy","8/30/2016 4:56:40 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",108,"T","Hardness by Calculation Method - Standard Methods 2340B - 19th Ed ","9/3/2014 12:00:00 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",707,"TMLF","Time missing in logger file.","7/30/2019 7:36:04 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",112,"TOC","Temperature outside of criteria","4/9/2015 9:10:23 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",192,"TT","analyte recalculated against alternate labeled compound(s)","6/15/2016 1:28:59 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",3,"U","Not Detected: The analyte was analyzed for, but was not detected at a level greater than or equal to the level of the adjusted Contract Required Quantitation Limit (CRQL) for sample and method. ","8/11/2006 11:50:00 PM","Non-Detect"
+"Result Measure Qualifier(MeasureQualifierCode)",831,"UDL","Lab's detection limit is not known/available for validation or comparison to the result.","4/10/2020 6:07:22 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",832,"UDQ","Lab's detection limit not known/available for comparison to the result; however with parameter specific evaluation determined to be quantified.","4/10/2020 6:07:22 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",188,"UNC","Value Not Confirmed","3/16/2016 1:04:27 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",749,"V","Surrogate recoveries out of range","12/16/2019 12:53:17 PM","Suspect"
+"Result Measure Qualifier(MeasureQualifierCode)",1167,"VS","compound identified verified by 2nd method","8/16/2021 11:03:38 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",758,"VVRR","Value verified by rerun","8/18/2020 1:54:00 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",1172,"VVRR2","value verified by rerun, 2nd method","8/16/2021 11:08:55 AM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",26,"ZZ","Blank-corrected data were indicated by the ""Z"" qualifier code. The laboratory reported the concentration of analyte to the nearest unit. These data were qualified as blank-corrected and as undetected when the blank correction resulted in a concentration below the DL.","8/31/2023 6:03:12 PM","Pass"
+"Result Measure Qualifier(MeasureQualifierCode)",311,"^","Yield outside of contractual acceptable range (USGS)","4/12/2017 3:14:21 PM","Suspect"
+NA,NA,"H;J","Hard-coded combination","8/7/2023 02:36:00 PM","Pass"
+NA,NA,"LT;MDL","Hard-coded combination","8/7/2023 05:00:00 PM","Non-Detect"
+NA,NA,"HMSR;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"J;QC","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"D;H","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"J;U","Hard-coded combination","8/7/2023 07:42:00 PM","Non-Detect"
+NA,NA,"H;LAC","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"FQC;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"B;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"FMS;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
+NA,NA,"D;U","Hard-coded combination","8/7/2023 07:42:00 PM","Non-Detect"
+NA,NA,"FSL;J","Hard-coded combination","8/7/2023 08:14:00 PM","Suspect"

--- a/inst/extdata/WQXMeasureQualifierCodeRef.csv
+++ b/inst/extdata/WQXMeasureQualifierCodeRef.csv
@@ -1,245 +1,233 @@
-"Domain","Unique.Identifier","Code","Description","Last.Change.Date","TADA.MeasureQualifierCode.Flag"
-"Result Measure Qualifier(MeasureQualifierCode)",307,"$","Incorrect sample container","4/12/2017 3:14:21 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1160,"&","biological organism established as dominant","8/16/2021 11:03:37 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1161,"(","blank greater than the sample-specific Critical Level","8/16/2021 11:03:37 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1162,")","sample specific MDC (Minimum Detectable Change) above contractual MDC","8/16/2021 11:03:38 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",308,"*","Sample was warm when received","4/12/2017 3:14:21 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",814,"+","Recovery is outside acceptance limits and/or RPD exceeds control limits","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1185,"2-5B","Result was between 2-5 times the blank concentration - set to Detected Not Quantified","5/31/2023 4:54:48 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",1186,"<2B","Result was <2 times the blank concentration - set to Not Detected","5/31/2023 4:54:48 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",1100,"=","Equal To","9/9/2020 11:38:33 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",55,"A","Compound not analyzed","8/22/2013 1:44:00 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1171,"AC","sample variability described see activity comment for more details","8/16/2021 11:08:55 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",206,"AL","Aldol condensation present. Analyte may not be present.","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",122,"ALK","Estimate, Alkylated PAH Sum","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",123,"ALT","Alternate Method","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",822,"AP","The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample. And serial dilution acceptance criteria not met","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1121,"AR","counts outside acceptable range","8/16/2021 11:05:27 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",5,"B","Detection in blank, Analyte found in sample and associated blank","4/24/2008 8:28:30 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",124,"BAC","Correction Factor, background","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",125,"BQL","Below Quantitation Limit","7/6/2016 4:09:14 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",126,"BRL","Below Reporting Limit","7/6/2016 4:09:17 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",821,"BS","Compound was found in the blank and sample","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1182,"BSR","Lab spiked blank acceptance criteria not met","11/12/2021 1:38:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1183,"BT","Detection in Trip Blank","11/12/2021 1:38:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",223,"BVER","Continuing calibration blank criteria was not met","9/28/2016 1:08:07 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",58,"C","Presence of compound may be due to contamination of sample during laboratory processing","8/22/2013 1:44:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",127,"C25","Dual Column result difference >25%","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",128,"CAJ","Correction Factor, lab","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",129,"CAN","No Result Reported, analysis canceled","3/16/2016 1:04:24 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",130,"CBC","No Result Reported, cannot be calculated","3/16/2016 1:04:24 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1122,"CBG","CC B G; Co-eluting congener, analyte found in sample and associated blank, and lock mass interference present","5/21/2021 4:56:03 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",131,"CBL","Correction Factor, blank","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",189,"CC","co-eluting congener","6/15/2016 1:28:59 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",132,"CDI","Correction Factor, dilution","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1126,"CG","CC G; Co-eluting congener and lock mass interference present","5/21/2021 5:10:50 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1128,"CKB","CC PK B; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and analyte found in sample and associated blank","5/21/2021 5:13:41 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1127,"CKBJ","CC PK B J;Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration), analyte found in sample and associated blank, and the reported result is an estimate (the value is less than the minimum calibration level","5/21/2021 5:12:53 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1129,"CKG","CC PK G; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and lock mass interference present","5/21/2021 5:17:08 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1130,"CKJ","CC PK J; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and the reported result is an estimate (the value is less than the minimum calibration level but greater than the estimated detection limit)","5/21/2021 5:18:08 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",133,"CLC","Correction Factor, other","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",207,"CNT","Non-acceptable colony counts.","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",134,"CON","Value Confirmed","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1180,"CSR","Calibration standard acceptance criteria not met","11/12/2021 1:38:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1131,"CUG","CC U G; Co-eluting congener, the analyte was not detected in the sample at the estimated detection limit and lock mass interference present","5/21/2021 5:18:42 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",11,"D","Contract Required Quantitation Limit (CRQL) not met due to sample matrix interference, dilution required.  ","5/14/2009 2:21:45 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1184,"D>T","Result dissolved concentration was greater than its total and the absolute difference was greater than or equal to the total MDL - set to Detected Not Quantified","5/31/2023 4:54:47 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",330,"DE","Serial dilution acceptance criteria not met.","8/22/2017 12:37:58 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",135,"DEC","Value Decensored -  reconstruct or remove the objectionable values of a measurement set","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",808,"DI","Dilution required","4/10/2020 6:07:21 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",73,"DL","Not Detected: The analyte was not detected at a level >= to the Method Detection Limit for the analysis.","11/25/2013 1:44:00 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",1168,"DOM","count >= 15 percent (dominant)","8/16/2021 11:03:38 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1001,"DT","Date value on logger was incorrect; Changed to date of sampling event; Date and Time considered suspect.","4/13/2020 7:13:06 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",54,"E","Concentration of analyte being analyzed exceeded calibration range of instrument.","2/13/2012 6:03:18 PM","Over-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",136,"ECI","Estimated Value, Coelution","3/16/2016 1:04:24 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",19,"EE","Identifies compounds whose concentration exceed the calibration range addition of the instrument for that specific analysis.","8/28/2009 5:04:35 PM","Over-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",788,"EER","No Result Reported, entry error; Original value is known to be incorrect due to a data entry error.  The correct value could not be determined. No result value was reported","1/23/2020 2:12:06 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",59,"EFAI","Equipment failure","8/22/2013 1:44:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",137,"EMPC","Estimated Maximum Possible Concentration","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",138,"ESD","Estimated Value, serial dilution difference","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",139,"EST","Estimated Value, outside limit of precision","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",140,"EVA","Estimated Value, multiple Aroclors","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",141,"EVAD","Estimated Value, degradation","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",142,"EVID","Estimated Value, tentatively identified compound","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",60,"F","Estimated value: compound failed initial calibration check (CCC) or QC criteria","8/22/2013 1:44:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",143,"FDB","Dry Blank, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",144,"FDC","Drift Check, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",145,"FDL","Lab Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",53,"FEQ","Field Equipment Questionable","1/11/2012 5:15:03 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",209,"FFB","Failed. Field blank not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",146,"FFD","Field Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",210,"FFS","Failed. Field spike not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",211,"FFT","Failed. Trip blank not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",829,"FH","Failed high at audit check during deployment. Could include pre, mid or post deployment check.","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",147,"FIS","Internal Standard, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",830,"FL","Failed low at audit check during deployment. Could include pre, mid or post deployment check.","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",148,"FLA","Field Lab Anomaly","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1060,"FLC","Linearity Check, failed","7/10/2020 12:31:13 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",208,"FLD","Failed. Lab duplicate not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",212,"FLS","Failed. Lab spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",304,"FMD","Failed. Matrix Spike Duplicate not acceptable.","11/18/2019 10:00:52 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",213,"FMS","Failed. Matrix spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",149,"FPC","Performance Check, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1165,"FPP","sample field preparation problem","8/16/2021 11:03:38 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",150,"FPR","Ongoing Precision and Recovery, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",151,"FQC","Quality Control, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",152,"FRS","Lab Reference, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",153,"FSD","Lab Spike Duplicate, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",215,"FSL","Failed. Spiked lab blank recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",214,"FSP","Failed. Surrogate spike recovery not acceptable.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",154,"FUB","Field Tubing Blank, failed","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",191,"G","lock mass interference present","6/15/2016 1:28:59 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",815,"GR4","The analyte present in the original sample is greater than 4 times the matrix spike concentration; therefore, control limits are not applicable","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",74,"GT","The listed result is greater than the upper quantitation limit for either the analytical method or the meter used for the measurement. Equivalent to the Legacy STORET Remark Code of L: Actual Value is known to be greater than the value given.","11/25/2013 1:44:00 PM","Over-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",155,"GXB","Estimated Value, greater than 10x blank","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",6,"H","Holding time exceeded: ","4/24/2008 8:28:31 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1002,"H2","Extraction or preparation was conducted outside of the recognized method holding time.","5/23/2023 9:56:04 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1003,"H3","Sample was received or analysis requested beyond the recognized method holding time.","5/23/2023 9:56:04 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1164,"HE","value extrapolated at high end","8/16/2021 11:03:38 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",819,"HH","Out High","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",156,"HIB","Likely Biased High","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",113,"HICC","Initial calibration criteria not met – high","4/9/2015 9:10:23 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",157,"HIM","High Moisture ","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",23,"HLBL","high labeled compound recovery in sample","2/19/2021 8:38:02 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",120,"HMSD","Matrix spike duplicate acceptance criteria not met – high","4/9/2015 9:10:25 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",24,"HMSR","high matrix spike recovery, potential high bias","5/19/2010 11:24:46 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",25,"HNRO","high native analyte recovery in OPR (or LCS), potential high bias","5/19/2010 11:24:46 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",827,"HQ","High Quality control measures","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",158,"HTH","Hard to Homogenize","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",27,"HVER","high calibration verification standard recovery, estimated value","5/19/2010 11:24:47 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",61,"I","Estimated value; compound failed initial calibration value","8/22/2013 1:44:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",159,"ICA","Incorrect Initial Calibration Associated with Sample","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",647,"IDL","Instrument Detection Limit, less than","2/21/2019 10:42:45 AM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",216,"INT","Interference suspected. Analyte may not be present.","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",224,"IQCOL","ICV,CCV,ICB,CCB, ISA, ISB, CRI, CRA, DLCK or MRL standard: Instrument related QC is outside acceptance limits","10/27/2016 7:54:50 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1170,"IS","instrument sensitivity problem","8/16/2021 11:08:55 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",118,"ISAC","Internal standard acceptance criteria not met","4/9/2015 9:10:25 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",160,"ISP","Improper Sample Preservation","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1181,"ISR**","Internal Standard acceptance criteria not met***retired***use ISAC","3/9/2022 10:35:35 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",49,"ITNA","Incubation time not attained","2/2/2011 5:07:31 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",48,"ITNM","Incubation temperature not maintained","2/2/2011 5:07:30 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1,"J","Estimated: The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample.","8/11/2006 11:50:00 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",7,"J+","Estimated: The analyte was positively identified and the associated numerical value... +++.","5/7/2009 1:08:20 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",57,"J-","The analyte was positively identified; the associated numerical value is the approximate concentration of the analyte in the sample, and may have a potential negative bias.","2/19/2016 8:34:06 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",68,"J-1","Estimated value. A full explanation is presented in the narrative.","9/28/2023 2:48:59 PM","Not Reviewed"
-"Result Measure Qualifier(MeasureQualifierCode)",64,"J-R","Approximate value result is below the reporting level but greater than the method detection limit","8/23/2021 11:04:25 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",161,"JCN","Sample Container Damaged, no sample lost","3/16/2016 1:04:25 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",162,"JCW","Sample Container Damaged, sample lost","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",66,"K","Value below the detection Limit.  For BOD: depletion is less than 1.0","8/22/2013 1:44:00 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",163,"KCF","Known Contamination, field","3/16/2016 1:04:25 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1061,"KCX","Known Contamination, unknown","7/10/2020 12:31:13 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",18,"KK","True bacterial concentration is assumed to be less than the reported value. ","8/28/2009 5:04:14 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",51,"L","Lowest available reporting limit for the analytical method used.","12/2/2011 4:24:36 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",165,"LAC","No Result Reported, lab accident","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",222,"LBF","Lab Failed, sample not analyzed","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",809,"LCS","LCS or LCSD","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1166,"LF","count < 0.5 percent","8/16/2021 11:03:38 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",114,"LICC","Initial calibration criteria not met – low","4/9/2015 9:10:23 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",217,"LIS","Lab internal standard(s) added to sample.","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",20,"LL","True bacterial concentration is assumed to be greater than the reported value. ","8/28/2009 5:04:50 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",28,"LLBL","low labeled compound recovery in sample","2/19/2021 12:00:00 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",218,"LLS","Value less than lower quality control standard.","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",121,"LMSD","Matrix spike duplicate acceptance criteria not met – low","4/9/2015 9:10:26 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",30,"LMSR","low matrix spike recovery, potential low bias","5/19/2010 11:24:47 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",31,"LNRO","low native analyte recovery in OPR (or LCS), potential low bias","5/19/2010 11:24:47 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1173,"LO","laboratory Control Sample (LCS) recovery outside of accept range","8/16/2021 11:09:58 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",166,"LOB","Likely Biased Low","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",32,"LOPR","low OPR (or LCS) recovery, potential low bias","5/19/2010 11:24:47 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",828,"LQ","Low Quality control measures","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",810,"LR","Operating Range","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",117,"LSSR","Surrogate standard acceptance criteria not met – low","4/9/2015 9:10:24 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",817,"LT","Less Than","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",834,"LTGTE","Result is less than the MQL but greater than or equal to the MDL","4/10/2020 6:07:23 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",33,"LVER","low calibration verification standard recovery, potential low bias","5/19/2010 11:24:47 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",168,"M6F","More Than 6 Flags Applied","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",813,"MDL","Method Detection Level","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1040,"MI","Matrix Interference","4/24/2020 8:50:16 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",816,"MSD","MS and/or MSD","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",119,"MSR","Matrix spike acceptance criteria not met","4/9/2015 9:10:25 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",67,"N","Presumptive evidence of a nontarget compound","8/22/2013 1:44:00 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",290,NA,"Not Applicable","11/14/2016 2:52:56 PM","Not Reviewed"
-"Result Measure Qualifier(MeasureQualifierCode)",169,"NAI","No Result Reported, interference","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",823,"NFNS","Comparison of nutrient fractions (e.g. filtered > unfiltered) or nutrient species (e.g. PO4 > TP) are not consistent","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",170,"NHS","Non-homogenous sample","3/16/2016 1:04:26 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",36,"NLBL","no labeled compound recovery in sample, rejected","5/19/2010 11:24:47 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",37,"NLRO","no labeled compound recovery in OPR (or LCS), rejected","5/19/2010 11:24:47 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",190,"NN","authentic recovery is not within method/contract control limits","6/15/2016 1:28:59 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",820,"NPNF","Normal protocol not followed","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1163,"NRB","negative result may indicate potential negative bias","8/16/2021 11:03:38 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",115,"NRO","Control sample acceptance criteria not met","4/9/2015 9:10:24 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",291,"NRP","No Result Possible","11/14/2016 2:52:56 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",171,"NRR","No Result Reported, other","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",791,"NRS","Non Representative Sample; Sample does not represent the environmental conditions.","1/23/2020 2:12:07 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",172,"NSQ","No Result Reported, insufficient quantity of sample","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",818,"NW","Not Within","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1140,"O","result determined by alternate method","8/11/2021 4:34:03 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",173,"OA3","Outlier, across stations","3/16/2016 1:04:26 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",174,"OS3","Outlier, single station","3/16/2016 1:04:26 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",175,"OTHER","Other","3/16/2016 1:04:26 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",220,"OUT","Result value is defined as an outlier by data owner","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1080,"P","PCDE interference","8/5/2020 9:55:33 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",826,"PB","Continuous probe biased","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1133,"PK","Peak deteced but did not meet quantification criteria (result reported represents the estimated maximum possible concentration)","5/21/2021 12:00:00 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",176,"PNQ","No Quantifiable Result Reported","3/16/2016 1:04:26 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1132,"PP","sample preparation problem","8/16/2021 11:05:27 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",177,"PPD","Spiked Blank Duplicate, failed","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1101,"PQL","PQL or LQL","9/9/2020 11:46:05 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",219,"PRE","Presumptive evidence that analyte is present.","8/30/2016 4:56:40 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",77,"Q","The result did not pass the lab quality checks and there was an insufficient amount of the sample for re-analysis.","11/25/2013 1:44:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1020,"QC","Quality Control problems","4/22/2020 8:09:48 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",178,"QCI","Quality Control incomplete","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",2,"R","Rejected: The sample results are unusable due to the quality of the data generated because certain criteria were not met. The analyte may or may not be present in the sample. ","8/11/2006 11:50:00 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",825,"RA","Results fall outside the normal limits of variability and do not meet Data Quality Objectives. Reanalyses were performed with consistent results. All QA ","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1120,"RC","See result comment","8/12/2021 9:36:56 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",179,"REX","Re-Prepared","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",180,"RIN","Re-Analyzed","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",181,"RLRS","Reporting limit raised, low total solids","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",42,"RMAX","result is a maximum value","5/19/2010 11:24:48 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",43,"RNAF","result not affected by noted QC issue","5/19/2010 11:24:48 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",45,"RNON","result reported as non-detect due to blank contamination","5/19/2010 11:24:48 AM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",1169,"RP","value reported is preferred","8/16/2021 11:08:54 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",46,"RPDX","RPD is MS/MSD pair exceeds criterion, estimated value","5/19/2010 11:24:48 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",203,"RPO","% RPD outside of acceptable limits","7/6/2016 4:04:47 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",811,"RR","Lab reported a result value","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",824,"RV","Results are within precision limits and are analytically equal.","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",812,"RVB","Result Value Between","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1134,"S2","Shipping time exceeded two day limit","6/1/2021 1:07:19 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",182,"SBB","Estimated Value, less than blank","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",183,"SCA","Suspected Contamination, lab analysis","3/16/2016 1:04:27 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",184,"SCF","Suspected Contamination, field","3/16/2016 1:04:27 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",185,"SCP","Suspected Contamination, lab preparation","3/16/2016 1:04:27 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",186,"SCX","Suspected Contamination, unknown","3/16/2016 1:04:27 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",226,"SD%EL","MS/MSD RPD exceeds control limits","10/27/2016 7:54:50 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",225,"SDROL","MS and/or MSD Recovery is outside acceptance limits","10/27/2016 7:54:50 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",187,"SLB","Spike level low compared to background","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",757,"SM","same method (USGS)","8/18/2020 1:51:06 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",833,"SS","Sample size difference","4/10/2020 6:07:23 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",116,"SSR","Surrogate standard acceptance criteria not met","4/9/2015 9:10:24 AM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1000,"SSRV","Surrogate or spike recovery value associated with sample analyte or analytes","5/23/2022 8:46:36 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",221,"SUS","Result value is defined as suspect by data owner. (HV) High variability: questionable precision and accuracy","8/30/2016 4:56:40 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",108,"T","Hardness by Calculation Method - Standard Methods 2340B - 19th Ed ","9/3/2014 12:00:00 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",707,"TMLF","Time missing in logger file.","7/30/2019 7:36:04 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",112,"TOC","Temperature outside of criteria","4/9/2015 9:10:23 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",192,"TT","analyte recalculated against alternate labeled compound(s)","6/15/2016 1:28:59 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",3,"U","Not Detected: The analyte was analyzed for, but was not detected at a level greater than or equal to the level of the adjusted Contract Required Quantitation Limit (CRQL) for sample and method. ","8/11/2006 11:50:00 PM","Non-Detect"
-"Result Measure Qualifier(MeasureQualifierCode)",831,"UDL","Lab's detection limit is not known/available for validation or comparison to the result.","4/10/2020 6:07:22 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",832,"UDQ","Lab's detection limit not known/available for comparison to the result; however with parameter specific evaluation determined to be quantified.","4/10/2020 6:07:22 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",188,"UNC","Value Not Confirmed","3/16/2016 1:04:27 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",749,"V","Surrogate recoveries out of range","12/16/2019 12:53:17 PM","Suspect"
-"Result Measure Qualifier(MeasureQualifierCode)",1167,"VS","compound identified verified by 2nd method","8/16/2021 11:03:38 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",758,"VVRR","Value verified by rerun","8/18/2020 1:54:00 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",1172,"VVRR2","value verified by rerun, 2nd method","8/16/2021 11:08:55 AM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",26,"ZZ","Blank-corrected data were indicated by the ""Z"" qualifier code. The laboratory reported the concentration of analyte to the nearest unit. These data were qualified as blank-corrected and as undetected when the blank correction resulted in a concentration below the DL.","8/31/2023 6:03:12 PM","Pass"
-"Result Measure Qualifier(MeasureQualifierCode)",311,"^","Yield outside of contractual acceptable range (USGS)","4/12/2017 3:14:21 PM","Suspect"
-NA,NA,"H;J","Hard-coded combination","8/7/2023 02:36:00 PM","Pass"
-NA,NA,"LT;MDL","Hard-coded combination","8/7/2023 05:00:00 PM","Non-Detect"
-NA,NA,"HMSR;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"J;QC","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"D;H","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"J;U","Hard-coded combination","8/7/2023 07:42:00 PM","Non-Detect"
-NA,NA,"H;LAC","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"FQC;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"B;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"FMS;J","Hard-coded combination","8/7/2023 07:42:00 PM","Suspect"
-NA,NA,"D;U","Hard-coded combination","8/7/2023 07:42:00 PM","Non-Detect"
-NA,NA,"FSL;J","Hard-coded combination","8/7/2023 08:14:00 PM","Suspect"
+Domain,Unique.Identifier,Code,Description,Last.Change.Date,TADA.MeasureQualifierCode.Flag
+Result Measure Qualifier(MeasureQualifierCode),307,$,Incorrect sample container,4/12/2017 15:14,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1160,&,biological organism established as dominant,8/16/2021 11:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),1161,(,blank greater than the sample-specific Critical Level,8/16/2021 11:03,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1162,),sample specific MDC (Minimum Detectable Change) above contractual MDC,8/16/2021 11:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),308,*,Sample was warm when received,4/12/2017 15:14,Pass
+Result Measure Qualifier(MeasureQualifierCode),814,+,Recovery is outside acceptance limits and/or RPD exceeds control limits,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1185,2-5B,Result was between 2-5 times the blank concentration - set to Detected Not Quantified,5/31/2023 16:54,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),1186,<2B,Result was <2 times the blank concentration - set to Not Detected,5/31/2023 16:54,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),1100,=,Equal To,9/9/2020 11:38,Pass
+Result Measure Qualifier(MeasureQualifierCode),55,A,Compound not analyzed,8/22/2013 13:44,Pass
+Result Measure Qualifier(MeasureQualifierCode),1171,AC,sample variability described see activity comment for more details,8/16/2021 11:08,Pass
+Result Measure Qualifier(MeasureQualifierCode),206,AL,Aldol condensation present. Analyte may not be present.,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),122,ALK,"Estimate, Alkylated PAH Sum",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),123,ALT,Alternate Method,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),822,AP,The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample. And serial dilution acceptance criteria not met,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),1121,AR,counts outside acceptable range,8/16/2021 11:05,Suspect
+Result Measure Qualifier(MeasureQualifierCode),5,B,"Detection in blank, Analyte found in sample and associated blank",4/24/2008 8:28,Pass
+Result Measure Qualifier(MeasureQualifierCode),124,BAC,"Correction Factor, background",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),125,BQL,Below Quantitation Limit,7/6/2016 16:09,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),126,BRL,Below Reporting Limit,7/6/2016 16:09,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),821,BS,Compound was found in the blank and sample,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1182,BSR,Lab spiked blank acceptance criteria not met,11/12/2021 13:38,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1183,BT,Detection in Trip Blank,11/12/2021 13:38,Suspect
+Result Measure Qualifier(MeasureQualifierCode),223,BVER,Continuing calibration blank criteria was not met,9/28/2016 13:08,Suspect
+Result Measure Qualifier(MeasureQualifierCode),58,C,Presence of compound may be due to contamination of sample during laboratory processing,8/22/2013 13:44,Suspect
+Result Measure Qualifier(MeasureQualifierCode),127,C25,Dual Column result difference >25%,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),128,CAJ,"Correction Factor, lab",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),129,CAN,"No Result Reported, analysis canceled",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),130,CBC,"No Result Reported, cannot be calculated",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1122,CBG,"CC B G; Co-eluting congener, analyte found in sample and associated blank, and lock mass interference present",5/21/2021 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),131,CBL,"Correction Factor, blank",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),189,CC,co-eluting congener,6/15/2016 13:28,Pass
+Result Measure Qualifier(MeasureQualifierCode),132,CDI,"Correction Factor, dilution",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),1126,CG,CC G; Co-eluting congener and lock mass interference present,5/21/2021 17:10,Pass
+Result Measure Qualifier(MeasureQualifierCode),1128,CKB,"CC PK B; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and analyte found in sample and associated blank",5/21/2021 17:13,Pass
+Result Measure Qualifier(MeasureQualifierCode),1127,CKBJ,"CC PK B J;Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration), analyte found in sample and associated blank, and the reported result is an estimate (the value is less than the minimum calibration level",5/21/2021 17:12,Pass
+Result Measure Qualifier(MeasureQualifierCode),1129,CKG,"CC PK G; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and lock mass interference present",5/21/2021 17:17,Pass
+Result Measure Qualifier(MeasureQualifierCode),1130,CKJ,"CC PK J; Co-eluting congener, peak detected but did not meet quantification criteria (result reported represents the estimated maximum possible concentration) and the reported result is an estimate (the value is less than the minimum calibration level but greater than the estimated detection limit)",5/21/2021 17:18,Pass
+Result Measure Qualifier(MeasureQualifierCode),133,CLC,"Correction Factor, other",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),207,CNT,Non-acceptable colony counts.,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),134,CON,Value Confirmed,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),1180,CSR,Calibration standard acceptance criteria not met,11/12/2021 13:38,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1131,CUG,"CC U G; Co-eluting congener, the analyte was not detected in the sample at the estimated detection limit and lock mass interference present",5/21/2021 17:18,Pass
+Result Measure Qualifier(MeasureQualifierCode),11,D,"Contract Required Quantitation Limit (CRQL) not met due to sample matrix interference, dilution required.  ",5/14/2009 14:21,Pass
+Result Measure Qualifier(MeasureQualifierCode),1184,D>T,Result dissolved concentration was greater than its total and the absolute difference was greater than or equal to the total MDL - set to Detected Not Quantified,5/31/2023 16:54,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),330,DE,Serial dilution acceptance criteria not met.,8/22/2017 12:37,Suspect
+Result Measure Qualifier(MeasureQualifierCode),135,DEC,Value Decensored -  reconstruct or remove the objectionable values of a measurement set,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),808,DI,Dilution required,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),73,DL,Not Detected: The analyte was not detected at a level >= to the Method Detection Limit for the analysis.,11/25/2013 13:44,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),1168,DOM,count >= 15 percent (dominant),8/16/2021 11:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),1001,DT,Date value on logger was incorrect; Changed to date of sampling event; Date and Time considered suspect.,4/13/2020 7:13,Pass
+Result Measure Qualifier(MeasureQualifierCode),54,E,Concentration of analyte being analyzed exceeded calibration range of instrument.,2/13/2012 18:03,Over-Detect
+Result Measure Qualifier(MeasureQualifierCode),136,ECI,"Estimated Value, Coelution",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),19,EE,Identifies compounds whose concentration exceed the calibration range addition of the instrument for that specific analysis.,8/28/2009 17:04,Over-Detect
+Result Measure Qualifier(MeasureQualifierCode),788,EER,"No Result Reported, entry error; Original value is known to be incorrect due to a data entry error.  The correct value could not be determined. No result value was reported",1/23/2020 14:12,Suspect
+Result Measure Qualifier(MeasureQualifierCode),59,EFAI,Equipment failure,8/22/2013 13:44,Suspect
+Result Measure Qualifier(MeasureQualifierCode),137,EMPC,Estimated Maximum Possible Concentration,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),138,ESD,"Estimated Value, serial dilution difference",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),139,EST,"Estimated Value, outside limit of precision",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),140,EVA,"Estimated Value, multiple Aroclors",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),141,EVAD,"Estimated Value, degradation",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),142,EVID,"Estimated Value, tentatively identified compound",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),60,F,Estimated value: compound failed initial calibration check (CCC) or QC criteria,8/22/2013 13:44,Suspect
+Result Measure Qualifier(MeasureQualifierCode),143,FDB,"Dry Blank, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),144,FDC,"Drift Check, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),145,FDL,"Lab Duplicate, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),53,FEQ,Field Equipment Questionable,1/11/2012 17:15,Suspect
+Result Measure Qualifier(MeasureQualifierCode),209,FFB,Failed. Field blank not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),146,FFD,"Field Duplicate, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),210,FFS,Failed. Field spike not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),211,FFT,Failed. Trip blank not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),829,FH,"Failed high at audit check during deployment. Could include pre, mid or post deployment check.",4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),147,FIS,"Internal Standard, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),830,FL,"Failed low at audit check during deployment. Could include pre, mid or post deployment check.",4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),148,FLA,Field Lab Anomaly,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1060,FLC,"Linearity Check, failed",7/10/2020 12:31,Suspect
+Result Measure Qualifier(MeasureQualifierCode),208,FLD,Failed. Lab duplicate not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),212,FLS,Failed. Lab spike recovery not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),304,FMD,Failed. Matrix Spike Duplicate not acceptable.,11/18/2019 10:00,Suspect
+Result Measure Qualifier(MeasureQualifierCode),213,FMS,Failed. Matrix spike recovery not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),149,FPC,"Performance Check, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1165,FPP,sample field preparation problem,8/16/2021 11:03,Suspect
+Result Measure Qualifier(MeasureQualifierCode),150,FPR,"Ongoing Precision and Recovery, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),151,FQC,"Quality Control, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),152,FRS,"Lab Reference, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),153,FSD,"Lab Spike Duplicate, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),215,FSL,Failed. Spiked lab blank recovery not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),214,FSP,Failed. Surrogate spike recovery not acceptable.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),154,FUB,"Field Tubing Blank, failed",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),191,G,lock mass interference present,6/15/2016 13:28,Suspect
+Result Measure Qualifier(MeasureQualifierCode),815,GR4,"The analyte present in the original sample is greater than 4 times the matrix spike concentration; therefore, control limits are not applicable",4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),74,GT,The listed result is greater than the upper quantitation limit for either the analytical method or the meter used for the measurement. Equivalent to the Legacy STORET Remark Code of L: Actual Value is known to be greater than the value given.,11/25/2013 13:44,Over-Detect
+Result Measure Qualifier(MeasureQualifierCode),155,GXB,"Estimated Value, greater than 10x blank",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),6,H,Holding time exceeded: ,4/24/2008 8:28,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1002,H2,Extraction or preparation was conducted outside of the recognized method holding time.,5/23/2023 9:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1003,H3,Sample was received or analysis requested beyond the recognized method holding time.,5/23/2023 9:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1164,HE,value extrapolated at high end,8/16/2021 11:03,Suspect
+Result Measure Qualifier(MeasureQualifierCode),819,HH,Out High,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),156,HIB,Likely Biased High,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),113,HICC,Initial calibration criteria not met – high,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),157,HIM,High Moisture ,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),23,HLBL,high labeled compound recovery in sample,2/19/2021 8:38,Pass
+Result Measure Qualifier(MeasureQualifierCode),120,HMSD,Matrix spike duplicate acceptance criteria not met – high,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),24,HMSR,"high matrix spike recovery, potential high bias",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),25,HNRO,"high native analyte recovery in OPR (or LCS), potential high bias",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),827,HQ,High Quality control measures,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),158,HTH,Hard to Homogenize,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),27,HVER,"high calibration verification standard recovery, estimated value",5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),61,I,Estimated value; compound failed initial calibration value,8/22/2013 13:44,Suspect
+Result Measure Qualifier(MeasureQualifierCode),159,ICA,Incorrect Initial Calibration Associated with Sample,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),647,IDL,"Instrument Detection Limit, less than",2/21/2019 10:42,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),216,INT,Interference suspected. Analyte may not be present.,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),224,IQCOL,"ICV,CCV,ICB,CCB, ISA, ISB, CRI, CRA, DLCK or MRL standard: Instrument related QC is outside acceptance limits",10/27/2016 7:54,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1170,IS,instrument sensitivity problem,8/16/2021 11:08,Suspect
+Result Measure Qualifier(MeasureQualifierCode),118,ISAC,Internal standard acceptance criteria not met,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),160,ISP,Improper Sample Preservation,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1181,ISR**,Internal Standard acceptance criteria not met***retired***use ISAC,3/9/2022 10:35,Suspect
+Result Measure Qualifier(MeasureQualifierCode),49,ITNA,Incubation time not attained,2/2/2011 17:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),48,ITNM,Incubation temperature not maintained,2/2/2011 17:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1,J,Estimated: The analyte was positively identified and the associated numerical value is the approximate concentration of the analyte in the sample.,8/11/2006 23:50,Pass
+Result Measure Qualifier(MeasureQualifierCode),7,J+,Estimated: The analyte was positively identified and the associated numerical value... +++.,5/7/2009 13:08,Pass
+Result Measure Qualifier(MeasureQualifierCode),57,J-,"The analyte was positively identified; the associated numerical value is the approximate concentration of the analyte in the sample, and may have a potential negative bias.",2/19/2016 8:34,Pass
+Result Measure Qualifier(MeasureQualifierCode),68,J-1,Estimated value. A full explanation is presented in the narrative.,9/28/2023 14:48,Not Reviewed
+Result Measure Qualifier(MeasureQualifierCode),64,J-R,Approximate value result is below the reporting level but greater than the method detection limit,8/23/2021 11:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),161,JCN,"Sample Container Damaged, no sample lost",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),162,JCW,"Sample Container Damaged, sample lost",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),66,K,Value below the detection Limit.  For BOD: depletion is less than 1.0,8/22/2013 13:44,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),163,KCF,"Known Contamination, field",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1061,KCX,"Known Contamination, unknown",7/10/2020 12:31,Suspect
+Result Measure Qualifier(MeasureQualifierCode),18,KK,True bacterial concentration is assumed to be less than the reported value. ,8/28/2009 17:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),51,L,Lowest available reporting limit for the analytical method used.,12/2/2011 16:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),165,LAC,"No Result Reported, lab accident",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),222,LBF,"Lab Failed, sample not analyzed",8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),809,LCS,LCS or LCSD,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),1166,LF,count < 0.5 percent,8/16/2021 11:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),114,LICC,Initial calibration criteria not met – low,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),217,LIS,Lab internal standard(s) added to sample.,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),20,LL,True bacterial concentration is assumed to be greater than the reported value. ,8/28/2009 17:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),28,LLBL,low labeled compound recovery in sample,2/19/2021 0:00,Pass
+Result Measure Qualifier(MeasureQualifierCode),218,LLS,Value less than lower quality control standard.,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),121,LMSD,Matrix spike duplicate acceptance criteria not met – low,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),30,LMSR,"low matrix spike recovery, potential low bias",5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),31,LNRO,"low native analyte recovery in OPR (or LCS), potential low bias",5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),1173,LO,laboratory Control Sample (LCS) recovery outside of accept range,8/16/2021 11:09,Suspect
+Result Measure Qualifier(MeasureQualifierCode),166,LOB,Likely Biased Low,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),32,LOPR,"low OPR (or LCS) recovery, potential low bias",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),828,LQ,Low Quality control measures,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),810,LR,Operating Range,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),117,LSSR,Surrogate standard acceptance criteria not met – low,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),817,LT,Less Than,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),834,LTGTE,Result is less than the MQL but greater than or equal to the MDL,4/10/2020 18:07,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),33,LVER,"low calibration verification standard recovery, potential low bias",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),168,M6F,More Than 6 Flags Applied,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),813,MDL,Method Detection Level,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1040,MI,Matrix Interference,4/24/2020 20:50,Suspect
+Result Measure Qualifier(MeasureQualifierCode),816,MSD,MS and/or MSD,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),119,MSR,Matrix spike acceptance criteria not met,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),67,N,Presumptive evidence of a nontarget compound,8/22/2013 13:44,Pass
+Result Measure Qualifier(MeasureQualifierCode),290,NA,Not Applicable,11/14/2016 14:52,Not Reviewed
+Result Measure Qualifier(MeasureQualifierCode),169,NAI,"No Result Reported, interference",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),823,NFNS,Comparison of nutrient fractions (e.g. filtered > unfiltered) or nutrient species (e.g. PO4 > TP) are not consistent,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),170,NHS,Non-homogenous sample,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),36,NLBL,"no labeled compound recovery in sample, rejected",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),37,NLRO,"no labeled compound recovery in OPR (or LCS), rejected",5/19/2010 11:24,Suspect
+Result Measure Qualifier(MeasureQualifierCode),190,NN,authentic recovery is not within method/contract control limits,6/15/2016 13:28,Suspect
+Result Measure Qualifier(MeasureQualifierCode),820,NPNF,Normal protocol not followed,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1163,NRB,negative result may indicate potential negative bias,8/16/2021 11:03,Suspect
+Result Measure Qualifier(MeasureQualifierCode),115,NRO,Control sample acceptance criteria not met,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),291,NRP,No Result Possible,11/14/2016 14:52,Suspect
+Result Measure Qualifier(MeasureQualifierCode),171,NRR,"No Result Reported, other",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),791,NRS,Non Representative Sample; Sample does not represent the environmental conditions.,1/23/2020 14:12,Suspect
+Result Measure Qualifier(MeasureQualifierCode),172,NSQ,"No Result Reported, insufficient quantity of sample",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),818,NW,Not Within,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),1140,O,result determined by alternate method,8/11/2021 16:34,Pass
+Result Measure Qualifier(MeasureQualifierCode),173,OA3,"Outlier, across stations",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),174,OS3,"Outlier, single station",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),175,OTHER,Other,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),220,OUT,Result value is defined as an outlier by data owner,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),1080,P,PCDE interference,8/5/2020 9:55,Suspect
+Result Measure Qualifier(MeasureQualifierCode),826,PB,Continuous probe biased,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),1133,PK,Peak deteced but did not meet quantification criteria (result reported represents the estimated maximum possible concentration),5/21/2021 0:00,Pass
+Result Measure Qualifier(MeasureQualifierCode),176,PNQ,No Quantifiable Result Reported,3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1132,PP,sample preparation problem,8/16/2021 11:05,Suspect
+Result Measure Qualifier(MeasureQualifierCode),177,PPD,"Spiked Blank Duplicate, failed",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),1101,PQL,PQL or LQL,9/9/2020 11:46,Pass
+Result Measure Qualifier(MeasureQualifierCode),219,PRE,Presumptive evidence that analyte is present.,8/30/2016 16:56,Pass
+Result Measure Qualifier(MeasureQualifierCode),77,Q,The result did not pass the lab quality checks and there was an insufficient amount of the sample for re-analysis.,11/25/2013 13:44,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1020,QC,Quality Control problems,4/22/2020 8:09,Suspect
+Result Measure Qualifier(MeasureQualifierCode),178,QCI,Quality Control incomplete,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),2,R,Rejected: The sample results are unusable due to the quality of the data generated because certain criteria were not met. The analyte may or may not be present in the sample. ,8/11/2006 23:50,Suspect
+Result Measure Qualifier(MeasureQualifierCode),825,RA,Results fall outside the normal limits of variability and do not meet Data Quality Objectives. Reanalyses were performed with consistent results. All QA ,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1120,RC,See result comment,8/12/2021 21:36,Pass
+Result Measure Qualifier(MeasureQualifierCode),179,REX,Re-Prepared,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),180,RIN,Re-Analyzed,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),181,RLRS,"Reporting limit raised, low total solids",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),42,RMAX,result is a maximum value,5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),43,RNAF,result not affected by noted QC issue,5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),45,RNON,result reported as non-detect due to blank contamination,5/19/2010 11:24,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),1169,RP,value reported is preferred,8/16/2021 11:08,Pass
+Result Measure Qualifier(MeasureQualifierCode),46,RPDX,"RPD is MS/MSD pair exceeds criterion, estimated value",5/19/2010 11:24,Pass
+Result Measure Qualifier(MeasureQualifierCode),203,RPO,% RPD outside of acceptable limits,7/6/2016 16:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),811,RR,Lab reported a result value,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),824,RV,Results are within precision limits and are analytically equal.,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),812,RVB,Result Value Between,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),1134,S2,Shipping time exceeded two day limit,6/1/2021 13:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),182,SBB,"Estimated Value, less than blank",3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),183,SCA,"Suspected Contamination, lab analysis",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),184,SCF,"Suspected Contamination, field",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),185,SCP,"Suspected Contamination, lab preparation",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),186,SCX,"Suspected Contamination, unknown",3/16/2016 13:04,Suspect
+Result Measure Qualifier(MeasureQualifierCode),226,SD%EL,MS/MSD RPD exceeds control limits,10/27/2016 7:54,Suspect
+Result Measure Qualifier(MeasureQualifierCode),225,SDROL,MS and/or MSD Recovery is outside acceptance limits,10/27/2016 7:54,Suspect
+Result Measure Qualifier(MeasureQualifierCode),187,SLB,Spike level low compared to background,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),757,SM,same method (USGS),8/18/2020 13:51,Pass
+Result Measure Qualifier(MeasureQualifierCode),833,SS,Sample size difference,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),116,SSR,Surrogate standard acceptance criteria not met,4/9/2015 9:10,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1000,SSRV,Surrogate or spike recovery value associated with sample analyte or analytes,5/23/2022 8:46,Pass
+Result Measure Qualifier(MeasureQualifierCode),221,SUS,Result value is defined as suspect by data owner. (HV) High variability: questionable precision and accuracy,8/30/2016 16:56,Suspect
+Result Measure Qualifier(MeasureQualifierCode),108,T,Hardness by Calculation Method - Standard Methods 2340B - 19th Ed ,9/3/2014 0:00,Pass
+Result Measure Qualifier(MeasureQualifierCode),707,TMLF,Time missing in logger file.,7/30/2019 7:36,Pass
+Result Measure Qualifier(MeasureQualifierCode),112,TOC,Temperature outside of criteria,4/9/2015 9:10,Pass
+Result Measure Qualifier(MeasureQualifierCode),192,TT,analyte recalculated against alternate labeled compound(s),6/15/2016 13:28,Pass
+Result Measure Qualifier(MeasureQualifierCode),3,U,"Not Detected: The analyte was analyzed for, but was not detected at a level greater than or equal to the level of the adjusted Contract Required Quantitation Limit (CRQL) for sample and method. ",8/11/2006 23:50,Non-Detect
+Result Measure Qualifier(MeasureQualifierCode),831,UDL,Lab's detection limit is not known/available for validation or comparison to the result.,4/10/2020 18:07,Suspect
+Result Measure Qualifier(MeasureQualifierCode),832,UDQ,Lab's detection limit not known/available for comparison to the result; however with parameter specific evaluation determined to be quantified.,4/10/2020 18:07,Pass
+Result Measure Qualifier(MeasureQualifierCode),188,UNC,Value Not Confirmed,3/16/2016 13:04,Pass
+Result Measure Qualifier(MeasureQualifierCode),749,V,Surrogate recoveries out of range,12/16/2019 12:53,Suspect
+Result Measure Qualifier(MeasureQualifierCode),1167,VS,compound identified verified by 2nd method,8/16/2021 11:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),758,VVRR,Value verified by rerun,8/18/2020 13:54,Pass
+Result Measure Qualifier(MeasureQualifierCode),1172,VVRR2,"value verified by rerun, 2nd method",8/16/2021 11:08,Pass
+Result Measure Qualifier(MeasureQualifierCode),26,ZZ,"Blank-corrected data were indicated by the ""Z"" qualifier code. The laboratory reported the concentration of analyte to the nearest unit. These data were qualified as blank-corrected and as undetected when the blank correction resulted in a concentration below the DL.",8/31/2023 18:03,Pass
+Result Measure Qualifier(MeasureQualifierCode),311,^,Yield outside of contractual acceptable range (USGS),4/12/2017 15:14,Suspect

--- a/man/TADA_FlagMeasureQualifierCode.Rd
+++ b/man/TADA_FlagMeasureQualifierCode.Rd
@@ -24,7 +24,7 @@ flaggedonly = TRUE, the function will filter the dataframe to show only the
 rows of data flagged as Suspect.}
 
 \item{define}{Boolean argument; the default is define = TRUE. When define = TRUE,
-the function will add an additional column (TADA.MethodQualifierCode.Def) providing
+the function will add an additional column (TADA.MeasureQualifierCode.Def) providing
 all available definitions for the MethodQualifierCodes for each result. When
 define = FALSE, no additional column is added.}
 }

--- a/man/TADA_FlagMeasureQualifierCode.Rd
+++ b/man/TADA_FlagMeasureQualifierCode.Rd
@@ -24,7 +24,7 @@ flaggedonly = TRUE, the function will filter the dataframe to show only the
 rows of data flagged as Suspect.}
 
 \item{define}{Boolean argument; the default is define = TRUE. When define = TRUE,
-the function will add an additional column (TADA.MethodQualifierCode) providing
+the function will add an additional column (TADA.MethodQualifierCode.Def) providing
 all available definitions for the MethodQualifierCodes for each result. When
 define = FALSE, no additional column is added.}
 }

--- a/man/TADA_FlagMeasureQualifierCode.Rd
+++ b/man/TADA_FlagMeasureQualifierCode.Rd
@@ -4,7 +4,12 @@
 \alias{TADA_FlagMeasureQualifierCode}
 \title{Check for results with suspect result Measure Qualifier Codes}
 \usage{
-TADA_FlagMeasureQualifierCode(.data, clean = FALSE, flaggedonly = FALSE)
+TADA_FlagMeasureQualifierCode(
+  .data,
+  clean = FALSE,
+  flaggedonly = FALSE,
+  define = TRUE
+)
 }
 \arguments{
 \item{.data}{TADA dataframe which must include the column 'MeasureQualifierCode'}
@@ -17,6 +22,11 @@ will be removed.}
 \item{flaggedonly}{Boolean argument; the default is flaggedonly = FALSE. When
 flaggedonly = TRUE, the function will filter the dataframe to show only the
 rows of data flagged as Suspect.}
+
+\item{define}{Boolean argument; the default is define = TRUE. When define = TRUE,
+the function will add an additional column (TADA.MethodQualifierCode) providing
+all available definitions for the MethodQualifierCodes for each result. When
+define = FALSE, no additional column is added.}
 }
 \value{
 This function adds the column "TADA.MeasureQualifierCode.Flag" to the dataframe


### PR DESCRIPTION
For TADA_MeasureQualifierCodeFlag adds an argument "define" with default set to to TRUE which creates a column called "TADA.MeasureQualifierCode.Define" which concatenates the qualifier code with its definition. This accommodates more than one qualifier code and will return definitions for any codes which have a matching description in the reference file.

I also updated TADA.MeasureQualifierCode.Flag to consider each qualifier code individually (rather than relying on hard-coded combinations). This required creating a hierarchy to assign flags if multiple codes had conflicting flags for one result. Current hierarchy is Suspect > Non-Detect > Over-Detect > Pass > Not Reviewed.

I also updated the search for missing codes to search by single codes, not combinations.