### PR TITLE
417 overview map bug

### DIFF
--- a/R/Figures.R
+++ b/R/Figures.R
@@ -422,8 +422,6 @@ TADA_OverviewMap <- function(.data) {
 
     site_legend <- subset(site_size, site_size$Point_size %in% unique(sumdat$radius))
 
-
-
     # set color palette
     # set color palette for small number of characteristics (even intervals, no bins)
     if (length(unique(param_diff)) == 1 & param_length < 10) {
@@ -431,7 +429,11 @@ TADA_OverviewMap <- function(.data) {
         palette = "Blues",
         levels = param_counts
       )
-    } else {
+    
+    } else if (length(unique(param_counts)) == 1) {
+      pal <- "orange"
+    
+      } else {
       # set breaks to occur only at integers for data sets requiring bins
       pretty.breaks <- unique(round(pretty(sumdat$Parameter_Count)))
 
@@ -498,7 +500,7 @@ TADA_OverviewMap <- function(.data) {
     # create legend for single parameter count value data sets
     if (length(param_diff) == 0) {
       map <- map %>% leaflet::addLegend("bottomright",
-                                        color = "#2171b5", labels = as.data.frame(param_counts),
+                                        color = "#2171b5", labels = param_counts,
                                         title = "Characteristics",
                                         opacity = 0.5)
     }
@@ -511,20 +513,17 @@ TADA_OverviewMap <- function(.data) {
     }
     
     # TADA_addPolys and TADA_addPoints are in Utilities.R
-    map2 <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
-    map2 <- TADA_addPolys(map2, AmericanIndianUrl, "Tribes", "American Indian", bbox)
-    map2 <- TADA_addPolys(map2, OffReservationUrl, "Tribes", "Off Reservation", bbox)
-    map2 <- TADA_addPolys(map2, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
-    map2 <- TADA_addPoints(map2, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
-    map2 <- TADA_addPoints(map2, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
-    map3 <- leaflet::addLayersControl(map2,
+    map <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
+    map <- TADA_addPolys(map, AmericanIndianUrl, "Tribes", "American Indian", bbox)
+    map <- TADA_addPolys(map, OffReservationUrl, "Tribes", "Off Reservation", bbox)
+    map <- TADA_addPolys(map, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
+    map <- TADA_addPoints(map, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
+    map <- TADA_addPoints(map, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
+    map <- leaflet::addLayersControl(map,
                                      overlayGroups = c("Tribes"),
                                      options = leaflet::layersControlOptions(collapsed = FALSE)
     )
 
-
-                       
-  
     return(map)
   })
 }

--- a/R/Figures.R
+++ b/R/Figures.R
@@ -425,13 +425,14 @@ TADA_OverviewMap <- function(.data) {
 
 
     # set color palette
+    # set color palette for small number of characteristics (even intervals, no bins)
     if (length(unique(param_diff)) == 1 & param_length < 10) {
       pal <- leaflet::colorFactor(
         palette = "Blues",
         levels = param_counts
       )
     } else {
-      # set breaks to occur only at integers
+      # set breaks to occur only at integers for data sets requiring bins
       pretty.breaks <- unique(round(pretty(sumdat$Parameter_Count)))
 
       pal <- leaflet::colorBin(
@@ -439,6 +440,15 @@ TADA_OverviewMap <- function(.data) {
         bins = pretty.breaks
       )
     }
+    
+    # create custom fill color function so that data sets with one value for parameter count are displayed correctly
+    customFillColor <- function(category, pal) {
+      if(length(param_diff > 0)) {
+        return(pal(category))
+      } else {
+        return("#2171b5")
+      }}
+    
 
     # Tribal layers will load by default in the overview map, restricted by the bounding box of the current dataset
     # They can be toggled on and off using a button (all layers work together and can't be turned on/off individually).
@@ -455,7 +465,7 @@ TADA_OverviewMap <- function(.data) {
     vbbox <- bbox %>%
       as.vector()
 
-    map <- leaflet::leaflet() %>%
+    map <- leaflet::leaflet()
       leaflet::addProviderTiles("Esri.WorldTopoMap", group = "World topo", options = leaflet::providerTileOptions(updateWhenZooming = FALSE, updateWhenIdle = TRUE)) %>%
       leaflet::clearShapes() %>% # get rid of whatever was there before if loading a second dataset
       leaflet::fitBounds(lng1 = vbbox[1], lat1 = vbbox[2], lng2 = vbbox[3], lat2 = vbbox[4]) %>% # fit to bounds of data in tadat$raw
@@ -466,7 +476,7 @@ TADA_OverviewMap <- function(.data) {
         lat = ~TADA.LatitudeMeasure,
         # sets color of monitoring site circles
         color = "red",
-        fillColor = ~ pal(Parameter_Count),
+        fillColor = customFillColor(sumdat$Parameter_Count, pal),
         fillOpacity = 0.7,
         stroke = TRUE,
         weight = 1.5,
@@ -479,15 +489,11 @@ TADA_OverviewMap <- function(.data) {
           "<br> Characteristic Count: ", sumdat$Parameter_Count
         )
       ) %>%
-      leaflet::addLegend("bottomright",
-        pal = pal, values = sumdat$Parameter_Count,
-        title = "Characteristics",
-        opacity = 0.5
-      ) %>%
       addLegendCustom(
         colors = "black",
         labels = site_legend$Sample_n, sizes = site_legend$Point_size * 2
       )
+    
     # TADA_addPolys and TADA_addPoints are in Utilities.R
     map <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
     map <- TADA_addPolys(map, AmericanIndianUrl, "Tribes", "American Indian", bbox)
@@ -496,9 +502,27 @@ TADA_OverviewMap <- function(.data) {
     map <- TADA_addPoints(map, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
     map <- TADA_addPoints(map, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
     map <- leaflet::addLayersControl(map,
-      overlayGroups = c("Tribes"),
-      options = leaflet::layersControlOptions(collapsed = FALSE)
+                                     overlayGroups = c("Tribes"),
+                                     options = leaflet::layersControlOptions(collapsed = FALSE)
     )
+    
+  # create conditional map legend
+  # create legend for single parameter count value data sets
+  if (length(param_diff) == 0) {
+    map <- map %>% leaflet::addLegend("bottomright",
+                       color = "#2171b5", labels = as.data.frame(param_counts),
+                       title = "Characteristics",
+                       opacity = 0.5)
+  }
+    # create legend for data sets with multiple factors/bins for parameter count
+    if (length(param_diff) > 0) {
+     map <- map %>% leaflet::addLegend("bottomright",
+                                       pal = pal, values = sumdat$Parameter_Count,
+                                       title = "Characteristics",
+                                       opacity = 0.5)
+    }
+                       
+  
     return(map)
   })
 }

--- a/R/Figures.R
+++ b/R/Figures.R
@@ -465,7 +465,7 @@ TADA_OverviewMap <- function(.data) {
     vbbox <- bbox %>%
       as.vector()
 
-    map <- leaflet::leaflet()
+    map <- leaflet::leaflet() %>%
       leaflet::addProviderTiles("Esri.WorldTopoMap", group = "World topo", options = leaflet::providerTileOptions(updateWhenZooming = FALSE, updateWhenIdle = TRUE)) %>%
       leaflet::clearShapes() %>% # get rid of whatever was there before if loading a second dataset
       leaflet::fitBounds(lng1 = vbbox[1], lat1 = vbbox[2], lng2 = vbbox[3], lat2 = vbbox[4]) %>% # fit to bounds of data in tadat$raw
@@ -494,6 +494,22 @@ TADA_OverviewMap <- function(.data) {
         labels = site_legend$Sample_n, sizes = site_legend$Point_size * 2
       )
     
+    # create conditional map legend
+    # create legend for single parameter count value data sets
+    if (length(param_diff) == 0) {
+      map <- map %>% leaflet::addLegend("bottomright",
+                                        color = "#2171b5", labels = as.data.frame(param_counts),
+                                        title = "Characteristics",
+                                        opacity = 0.5)
+    }
+    # create legend for data sets with multiple factors/bins for parameter count
+    if (length(param_diff) > 0) {
+      map <- map %>% leaflet::addLegend("bottomright",
+                                        pal = pal, values = sumdat$Parameter_Count,
+                                        title = "Characteristics",
+                                        opacity = 0.5)
+    }
+    
     # TADA_addPolys and TADA_addPoints are in Utilities.R
     map <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
     map <- TADA_addPolys(map, AmericanIndianUrl, "Tribes", "American Indian", bbox)
@@ -506,21 +522,7 @@ TADA_OverviewMap <- function(.data) {
                                      options = leaflet::layersControlOptions(collapsed = FALSE)
     )
     
-  # create conditional map legend
-  # create legend for single parameter count value data sets
-  if (length(param_diff) == 0) {
-    map <- map %>% leaflet::addLegend("bottomright",
-                       color = "#2171b5", labels = as.data.frame(param_counts),
-                       title = "Characteristics",
-                       opacity = 0.5)
-  }
-    # create legend for data sets with multiple factors/bins for parameter count
-    if (length(param_diff) > 0) {
-     map <- map %>% leaflet::addLegend("bottomright",
-                                       pal = pal, values = sumdat$Parameter_Count,
-                                       title = "Characteristics",
-                                       opacity = 0.5)
-    }
+  
                        
   
     return(map)

--- a/R/Figures.R
+++ b/R/Figures.R
@@ -448,7 +448,7 @@ TADA_OverviewMap <- function(.data) {
       } else {
         return("#2171b5")
       }}
-    
+  
 
     # Tribal layers will load by default in the overview map, restricted by the bounding box of the current dataset
     # They can be toggled on and off using a button (all layers work together and can't be turned on/off individually).
@@ -492,7 +492,7 @@ TADA_OverviewMap <- function(.data) {
       addLegendCustom(
         colors = "black",
         labels = site_legend$Sample_n, sizes = site_legend$Point_size * 2
-      )
+      ) 
     
     # create conditional map legend
     # create legend for single parameter count value data sets
@@ -510,19 +510,19 @@ TADA_OverviewMap <- function(.data) {
                                         opacity = 0.5)
     }
     
-    # # TADA_addPolys and TADA_addPoints are in Utilities.R
-    # map2 <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
-    # map2 <- TADA_addPolys(map2, AmericanIndianUrl, "Tribes", "American Indian", bbox)
-    # map2 <- TADA_addPolys(map2, OffReservationUrl, "Tribes", "Off Reservation", bbox)
-    # map2 <- TADA_addPolys(map2, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
-    # map2 <- TADA_addPoints(map2, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
-    # map2 <- TADA_addPoints(map2, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
-    # map3 <- leaflet::addLayersControl(map2,
-    #                                  overlayGroups = c("Tribes"),
-    #                                  options = leaflet::layersControlOptions(collapsed = FALSE)
-    # )
-    # 
-    # 
+    # TADA_addPolys and TADA_addPoints are in Utilities.R
+    map2 <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
+    map2 <- TADA_addPolys(map2, AmericanIndianUrl, "Tribes", "American Indian", bbox)
+    map2 <- TADA_addPolys(map2, OffReservationUrl, "Tribes", "Off Reservation", bbox)
+    map2 <- TADA_addPolys(map2, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
+    map2 <- TADA_addPoints(map2, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
+    map2 <- TADA_addPoints(map2, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
+    map3 <- leaflet::addLayersControl(map2,
+                                     overlayGroups = c("Tribes"),
+                                     options = leaflet::layersControlOptions(collapsed = FALSE)
+    )
+
+
                        
   
     return(map)

--- a/R/Figures.R
+++ b/R/Figures.R
@@ -510,19 +510,19 @@ TADA_OverviewMap <- function(.data) {
                                         opacity = 0.5)
     }
     
-    # TADA_addPolys and TADA_addPoints are in Utilities.R
-    map <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
-    map <- TADA_addPolys(map, AmericanIndianUrl, "Tribes", "American Indian", bbox)
-    map <- TADA_addPolys(map, OffReservationUrl, "Tribes", "Off Reservation", bbox)
-    map <- TADA_addPolys(map, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
-    map <- TADA_addPoints(map, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
-    map <- TADA_addPoints(map, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
-    map <- leaflet::addLayersControl(map,
-                                     overlayGroups = c("Tribes"),
-                                     options = leaflet::layersControlOptions(collapsed = FALSE)
-    )
-    
-  
+    # # TADA_addPolys and TADA_addPoints are in Utilities.R
+    # map2 <- TADA_addPolys(map, AKAllotmentsUrl, "Tribes", "Alaska Allotments", bbox)
+    # map2 <- TADA_addPolys(map2, AmericanIndianUrl, "Tribes", "American Indian", bbox)
+    # map2 <- TADA_addPolys(map2, OffReservationUrl, "Tribes", "Off Reservation", bbox)
+    # map2 <- TADA_addPolys(map2, OKTribeUrl, "Tribes", "Oklahoma Tribe", bbox)
+    # map2 <- TADA_addPoints(map2, AKVillagesUrl, "Tribes", "Alaska Native Villages", bbox)
+    # map2 <- TADA_addPoints(map2, VATribeUrl, "Tribes", "Virginia Tribe", bbox)
+    # map3 <- leaflet::addLayersControl(map2,
+    #                                  overlayGroups = c("Tribes"),
+    #                                  options = leaflet::layersControlOptions(collapsed = FALSE)
+    # )
+    # 
+    # 
                        
   
     return(map)

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -984,6 +984,7 @@ TADA_addPolys <- function(map, url, layergroup, layername, bbox = NULL) {
   if (!(areaColumn %in% colnames(layer))) {
     areaColumn <- "AREA_KM"
   }
+  
   map <-
     leaflet::addPolygons(
       map,
@@ -993,7 +994,7 @@ TADA_addPolys <- function(map, url, layergroup, layername, bbox = NULL) {
       smoothFactor = 0.5,
       opacity = 1.0,
       fillOpacity = 0.2,
-      fillColor = ~ leaflet::colorQuantile("Oranges", layer[[areaColumn]])(layer[[areaColumn]]),
+      fillColor = ~ leaflet::colorNumeric("Oranges", layer[[areaColumn]])(layer[[areaColumn]]),
       highlightOptions = leaflet::highlightOptions(
         color = "white",
         weight = 2,


### PR DESCRIPTION
Fix for tribal boundaries not appearing for some queries. This fix works for the "PECHANGA_WQX" and "PENOBSCOTINDIANNATIONDNR" queries.

I switched the fillColor argument in TADA_AddPolys to colorNumeric, rather than colorQuantile. 