### PR TITLE
440 cant transform a data frame with duplicate names

### DIFF
--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -721,8 +721,7 @@ TADA_FindNearbySites <- function(.data, dist_buffer = 100) {
 #' }
 #'
 TADA_RandomTestingData <- function(number_of_days = 1, choose_random_state = FALSE, autoclean = TRUE) {
-  
-  RandomTestSetup <- function(){
+  while(TRUE) {
   # choose a random day within the last 20 years
   twenty_yrs_ago <- Sys.Date() - 20 * 365
   random_start_date <- twenty_yrs_ago + sample(20 * 365, 1)
@@ -761,45 +760,12 @@ TADA_RandomTestingData <- function(number_of_days = 1, choose_random_state = FAL
       applyautoclean = FALSE
     )
   }
-}
 
-  while (dim(dat)[1] == 0) {
-    dat <- RandomTestSetup()
-    if (dim(dat[1]) > 0) {
-      break
+  if (nrow(dat) > 0) {
+  return(dat)
     }
   }
-
-  return(dat)
 }
-
-# Generate a random data retrieval dataset (internal, for testthat's)
-# samples a random 90 days in the past 20 years using
-# TADA_DataRetrieval. Built to use in testthat and for developer testing of new
-# functions on random datasets.
-TADA_RandomStateTestingSet <- function(number_of_days = 90) {
-  load(system.file("extdata", "statecodes_df.Rdata", package = "TADA"))
-  
-  dat <- data.frame()
-  
-  state <- sample(statecodes_df$STUSAB, 1)
-  twenty_yrs_ago <- Sys.Date() - 20 * 365
-  random_start_date <- twenty_yrs_ago + sample(20 * 365, 1)
-  # changed default to 2 days instead of 90
-  end_date <- random_start_date + number_of_days
-
-  print(paste0(state, " from ", random_start_date, " to ", end_date))
-
-  # removed state input
-  dat <- TADA_DataRetrieval(startDate = as.character(random_start_date), endDate = as.character(end_date), statecode = state)
-
-  if (dim(dat)[1] < 1) {
-    dat <- Data_NCTCShepherdstown_HUC12
-  }
-
-  return(dat)
-}
-
 
 #' Aggregate multiple result values to a min, max, or mean
 #'

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -721,6 +721,8 @@ TADA_FindNearbySites <- function(.data, dist_buffer = 100) {
 #' }
 #'
 TADA_RandomTestingData <- function(number_of_days = 1, choose_random_state = FALSE, autoclean = TRUE) {
+  
+  RandomTestSetup <- function(){
   # choose a random day within the last 20 years
   twenty_yrs_ago <- Sys.Date() - 20 * 365
   random_start_date <- twenty_yrs_ago + sample(20 * 365, 1)
@@ -759,9 +761,13 @@ TADA_RandomTestingData <- function(number_of_days = 1, choose_random_state = FAL
       applyautoclean = FALSE
     )
   }
+}
 
-  if (dim(dat)[1] < 1) {
-    dat <- Data_NCTCShepherdstown_HUC12
+  while (dim(dat)[1] == 0) {
+    dat <- RandomTestSetup()
+    if (dim(dat[1]) > 0) {
+      break
+    }
   }
 
   return(dat)
@@ -773,6 +779,9 @@ TADA_RandomTestingData <- function(number_of_days = 1, choose_random_state = FAL
 # functions on random datasets.
 TADA_RandomStateTestingSet <- function(number_of_days = 90) {
   load(system.file("extdata", "statecodes_df.Rdata", package = "TADA"))
+  
+  dat <- data.frame()
+  
   state <- sample(statecodes_df$STUSAB, 1)
   twenty_yrs_ago <- Sys.Date() - 20 * 365
   random_start_date <- twenty_yrs_ago + sample(20 * 365, 1)


### PR DESCRIPTION
Updated TADA_RandomTestingData to run until a data frame containing > 0 rows is returned. Removed TADA_RandomStateTestingSet because the choose_random_stat option in TADA_RandomTestingData allows the same type of random query to be run without requiring an additional function.