### PR TITLE
613 tada autofilter should generate a flag column

### DIFF
--- a/R/RequiredCols.R
+++ b/R/RequiredCols.R
@@ -170,6 +170,7 @@ require.cols <- c(
   "LaboratoryName",
   "ResultLaboratoryCommentText",
   "ActivityIdentifier", # required
+  "TADA.AutoFilter.Flag",
 
   # Organization (e.g. data submitter)
   "OrganizationIdentifier", # required

--- a/R/RequiredCols.R
+++ b/R/RequiredCols.R
@@ -170,7 +170,6 @@ require.cols <- c(
   "LaboratoryName",
   "ResultLaboratoryCommentText",
   "ActivityIdentifier", # required
-  "TADA.AutoFilter.Flag",
 
   # Organization (e.g. data submitter)
   "OrganizationIdentifier", # required

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -196,12 +196,19 @@ TADA_CheckColumns <- function(.data, expected_cols) {
 #' converted to an average of the two numbers. Result values
 #' containing any other text or non-numeric characters become NA in
 #' the newly created "TADA.COLUMN NAME" and labeled accordingly in "TADA.COLUMN
-#' NAME DataTypes.Flag".
+#' NAME DataTypes.Flag". When clean = TRUE, rows that cannot be converted to
+#' numeric are removed. When clean = FALSE, no rows are removed. Default is
+#' clean = FALSE. When flaggedonly = TRUE, data frame is filtered to show only
+#' rows with non-numeric result values. Default is flaggedonly = FALSE.
 #'
 #'
 #' @param .data A TADA profile object
 #' @param col A character column to be converted to numeric
-#'
+#' @param clean Boolean argument; removes non-numeric result values from the
+#' data frame when clean = TRUE. Default is clean = FALSE.
+#' @param flaggedonly Boolean argument; filters dataframe to show only
+#' non-numeric result values when flaggedonly = TRUE. Default is flaggedonly
+#' = FALSE.
 #' @param percent.ave Boolean argument; default is percent.ave = TRUE. When
 #' clean = TRUE, any percent range values will be averaged. When
 #' percent.ave = FALSE, percent range values are not averaged, but are flagged.
@@ -229,9 +236,15 @@ TADA_CheckColumns <- function(.data, expected_cols) {
 #'   )
 #' unique(HandleSpecialChars_DetLimMeasureValue$
 #'   TADA.DetectionQuantitationLimitMeasure.MeasureValueDataTypes.Flag)
-TADA_ConvertSpecialChars <- function(.data, col, percent.ave = TRUE) {
+TADA_ConvertSpecialChars <- function(.data, col, percent.ave = TRUE,
+                                     clean = FALSE, flaggedonly = FALSE) {
   if (!col %in% names(.data)) {
     stop("Suspect column name specified for input dataset.")
+  }
+
+  # check that clean and flaggedonly are not both TRUE
+  if (clean == TRUE & flaggedonly == TRUE) {
+    stop("Function not executed because clean and flaggedonly cannot both be TRUE")
   }
 
   # Define new column names
@@ -353,7 +366,23 @@ TADA_ConvertSpecialChars <- function(.data, col, percent.ave = TRUE) {
 
   clean.data <- TADA_OrderCols(clean.data)
 
-  return(clean.data)
+  if (flaggedonly == FALSE) {
+    if (clean == TRUE) {
+      clean.data <- clean.data %>%
+        dplyr::filter(!(!!rlang::sym(flagcol)) %in% c("NA - Not Available", "Text"))
+
+      return(clean.data)
+    }
+
+    if (clean == FALSE) {
+      return(clean.data)
+    }
+  }
+
+  if (flaggedonly == TRUE) {
+    clean.data <- clean.data %>%
+      dplyr::filter(!!rlang::sym(flagcol) %in% c("NA - Not Available", "Text"))
+  }
 }
 
 #' Substitute Preferred Characteristic Name for Deprecated Names

--- a/R/autoFilter.R
+++ b/R/autoFilter.R
@@ -412,78 +412,22 @@ TADA_AnalysisDataFilter <- function(.data,
 
 #' AutoFilter
 #'
-#' This function removes or flags rows where the result value is not numeric to
-#' prepare a dataframe for quantitative analyses. Ideally, this function should
-#' be run after other data cleaning, QA/QC, and harmonization steps are
-#' completed using other TADA package functions, or manually. Specifically,
-#' this function removes rows with "Text" and "NA - Not Available"
-#' in the TADA.ResultMeasureValueDataTypes.Flag column, or NA in the
-#' TADA.ResultMeasureValue column. In addition, this function also removes or
-#' flags results with QA/QC ActivityTypeCodes. This function also removes any
-#' columns not required for TADA workflow where all values are equal to NA.
-#' It provides a warning message identifying any TADA required columns
-#' containing only NA values which were removed.
+#' This function also removes any columns not required for the TADA workflow
+#' where all values are equal to NA. It provides a warning message identifying
+#' any TADA required columns containing only NA values.
 #'
 #' @param .data TADA dataframe
-#' @param clean Boolean argument. When clean = TRUE, rows where the result
-#' value is not numeric are removed. When clean = FALSE, rows with non-numeric
-#' result values are flagged with a removal reason in the new
-#' TADA.AutoFilter.Flag column. Default is clean = FALSE.
 #'
-#' @return .data with rows non-quantitative and QA/QC results removed or
-#' flagged.
+#' @return .data with any non-required columns containing only NA values
+#' removed.
 #'
 #' @export
 #'
 #' @examples
 #' TADA_filtered <- TADA_AutoFilter(Data_Nutrients_UT)
-TADA_AutoFilter <- function(.data, clean = FALSE) {
+TADA_AutoFilter <- function(.data) {
   # check .data is data.frame
   TADA_CheckType(.data, "data.frame", "Input object")
-
-  TADA_CheckColumns(.data, c(
-    "ActivityTypeCode", "MeasureQualifierCode",
-    "TADA.ResultMeasureValueDataTypes.Flag",
-    "TADA.ResultMeasureValue", "TADA.ActivityMediaName",
-    "ActivityTypeCode"
-  ))
-
-  # keep track of starting and ending number of rows
-  start <- dim(.data)[1]
-
-
-  # run TADA_FindQCActivities if needed
-  if (("TADA.ActivityType.Flag" %in% colnames(.data)) == TRUE) {
-    .data <- .data
-  }
-
-  if (("TADA.ActivityType.Flag" %in% colnames(.data)) == FALSE) {
-    .data <- TADA_FindQCActivities(.data, clean = FALSE, flaggedonly = FALSE)
-  }
-
-  if (clean == TRUE) {
-
-  # remove text, NAs and QC results
-  .data <- dplyr::filter(.data, TADA.ResultMeasureValueDataTypes.Flag != "Text" &
-    TADA.ResultMeasureValueDataTypes.Flag != "NA - Not Available" &
-    TADA.ActivityType.Flag == "Non_QC" & # filter out QA/QC ActivityTypeCode's
-    !is.na(TADA.ResultMeasureValue))
-
-  print("TADA_AutoFilter: removing rows not suitable for quantitative analysis.")
-  }
-
-  if (clean == FALSE) {
-
-    # flag text, NAs and QC results
-    .data <- .data %>%
-      dplyr::mutate(TADA.AutoFilter.Flag = dplyr::case_when(
-      TADA.ResultMeasureValueDataTypes.Flag == "Text" ~ "Result data type is not numeric.",
-      TADA.ResultMeasureValueDataTypes.Flag != "NA - Not Available" ~ "Result value is NA.",
-      TADA.ActivityType.Flag != "Non_QC" ~ "Result is from a quality control sample.",
-      .default = NA))
-
-    print("TADA_AutoFilter: flagging rows not suitable for quantitative analysis.")
-  }
 
   # remove columns that are not required for TADA workflow
   print("TADA_AutoFilter: removing columns not required for TADA workflow if they contain only NAs.")
@@ -493,8 +437,10 @@ TADA_AutoFilter <- function(.data, clean = FALSE) {
     purrr::keep(~ all(is.na(.x))) %>%
     names()
 
-  # create list of columns to be removed by comparing columns containing all NA values to required columns.
-  # any required columns with all NA values will be excluded from the list of columns to remove.
+  # create list of columns to be removed by comparing columns containing all NA
+  # values to required columns.
+  # any required columns with all NA values will be excluded from the list of
+  # columns to remove.
   remove.cols <- setdiff(na.cols, require.cols)
 
   # remove not required columns containing all NA values from dataframe.
@@ -513,9 +459,10 @@ TADA_AutoFilter <- function(.data, clean = FALSE) {
   # create character string for list of removed columns
   remove.paste <- stringi::stri_replace_last_fixed(paste(as.character(remove.cols), collapse = ", ", sep = ""), ", ", " and ")
 
-  # print list of columns removed from dataframe
+  # print list of columns removed from data frame
   if (length(remove.cols) > 0) {
-    print(paste0("The following column(s) were removed as they contained only NAs: ", remove.paste, "."))
+    print(paste0("The following column(s) were removed as they contained only NAs ",
+                 "and are not required for the TADA workflow: ", remove.paste, "."))
   } else {
     print("All columns contained some non-NA values and were retained in the dataframe.")
   }
@@ -533,17 +480,6 @@ TADA_AutoFilter <- function(.data, clean = FALSE) {
 
   # remove intermediate objects
   rm(req.paste, remove.cols, remove.paste, req.check)
-
-  end <- dim(.data)[1]
-
-  # print number of results removed
-  if (!start == end) {
-    net <- start - end
-    print(paste0("Function removed ", format(net, big.mark = ",", scientific = FALSE),
-                 " results. These results are either text or NA ",
-                 "and cannot be plotted or represent quality control activities ",
-                 "(not routine samples or measurements)."))
-  }
 
   return(.data)
 }

--- a/R/autoFilter.R
+++ b/R/autoFilter.R
@@ -528,7 +528,7 @@ TADA_AutoFilter <- function(.data, clean = FALSE) {
     print(paste0("TADA_AutoFilter: TADA Required column(s) ", req.paste,
                  " contain only NA values. This may impact other TADA functions."))
   } else {
-    print("TADA_AutoFilterAll TADA Required columns contain some non-NA values.")
+    print("TADA_AutoFilter: All TADA Required columns contain some non-NA values.")
   }
 
   # remove intermediate objects

--- a/R/autoFilter.R
+++ b/R/autoFilter.R
@@ -428,7 +428,7 @@ TADA_AnalysisDataFilter <- function(.data,
 #' @param clean Boolean argument. When clean = TRUE, rows where the result
 #' value is not numeric are removed. When clean = FALSE, rows with non-numeric
 #' result values are flagged with a removal reason in the new
-#' TADA.AutoFilter.Flag column.
+#' TADA.AutoFilter.Flag column. Default is clean = FALSE.
 #'
 #' @return .data with rows non-quantitative and QA/QC results removed or
 #' flagged.
@@ -437,7 +437,7 @@ TADA_AnalysisDataFilter <- function(.data,
 #'
 #' @examples
 #' TADA_filtered <- TADA_AutoFilter(Data_Nutrients_UT)
-TADA_AutoFilter <- function(.data) {
+TADA_AutoFilter <- function(.data, clean = FALSE) {
   # check .data is data.frame
   TADA_CheckType(.data, "data.frame", "Input object")
 
@@ -451,6 +451,7 @@ TADA_AutoFilter <- function(.data) {
   # keep track of starting and ending number of rows
   start <- dim(.data)[1]
 
+
   # run TADA_FindQCActivities if needed
   if (("TADA.ActivityType.Flag" %in% colnames(.data)) == TRUE) {
     .data <- .data
@@ -460,14 +461,32 @@ TADA_AutoFilter <- function(.data) {
     .data <- TADA_FindQCActivities(.data, clean = FALSE, flaggedonly = FALSE)
   }
 
+  if (clean == TRUE) {
+
   # remove text, NAs and QC results
   .data <- dplyr::filter(.data, TADA.ResultMeasureValueDataTypes.Flag != "Text" &
     TADA.ResultMeasureValueDataTypes.Flag != "NA - Not Available" &
     TADA.ActivityType.Flag == "Non_QC" & # filter out QA/QC ActivityTypeCode's
     !is.na(TADA.ResultMeasureValue))
 
+  print("TADA_AutoFilter: removing rows not suitable for quantitative analysis.")
+  }
+
+  if (clean == FALSE) {
+
+    # flag text, NAs and QC results
+    .data <- .data %>%
+      dplyr::mutate(TADA.AutoFilter.Flag = dplyr::case_when(
+      TADA.ResultMeasureValueDataTypes.Flag == "Text" ~ "Result data type is not numeric.",
+      TADA.ResultMeasureValueDataTypes.Flag != "NA - Not Available" ~ "Result value is NA.",
+      TADA.ActivityType.Flag != "Non_QC" ~ "Result is from a quality control sample.",
+      .default = NA))
+
+    print("TADA_AutoFilter: flagging rows not suitable for quantitative analysis.")
+  }
+
   # remove columns that are not required for TADA workflow
-  print("TADA_Autofilter: removing columns not required for TADA workflow if they contain only NAs.")
+  print("TADA_AutoFilter: removing columns not required for TADA workflow if they contain only NAs.")
 
   # create list of columns containing all NA values.
   na.cols <- .data %>%
@@ -502,13 +521,14 @@ TADA_AutoFilter <- function(.data) {
   }
 
   # remove columns that are not required for TADA workflow
-  print("TADA_Autofilter: checking required columns for non-NA values.")
+  print("TADA_AutoFilter: checking required columns for non-NA values.")
 
   # if some required columns contain only NA values print a warning message.
   if (length(req.check) > 0) {
-    print(paste0("TADA Required column(s) ", req.paste, " contain only NA values. This may impact other TADA functions."))
+    print(paste0("TADA_AutoFilter: TADA Required column(s) ", req.paste,
+                 " contain only NA values. This may impact other TADA functions."))
   } else {
-    print("All TADA Required columns contain some non-NA values.")
+    print("TADA_AutoFilterAll TADA Required columns contain some non-NA values.")
   }
 
   # remove intermediate objects
@@ -519,7 +539,10 @@ TADA_AutoFilter <- function(.data) {
   # print number of results removed
   if (!start == end) {
     net <- start - end
-    print(paste0("Function removed ", net, " results. These results are either text or NA and cannot be plotted or represent quality control activities (not routine samples or measurements)."))
+    print(paste0("Function removed ", format(net, big.mark = ",", scientific = FALSE),
+                 " results. These results are either text or NA ",
+                 "and cannot be plotted or represent quality control activities ",
+                 "(not routine samples or measurements)."))
   }
 
   return(.data)

--- a/R/autoFilter.R
+++ b/R/autoFilter.R
@@ -412,21 +412,26 @@ TADA_AnalysisDataFilter <- function(.data,
 
 #' AutoFilter
 #'
-#' This function removes rows where the result value is not numeric to
+#' This function removes or flags rows where the result value is not numeric to
 #' prepare a dataframe for quantitative analyses. Ideally, this function should
 #' be run after other data cleaning, QA/QC, and harmonization steps are
 #' completed using other TADA package functions, or manually. Specifically,
 #' this function removes rows with "Text" and "NA - Not Available"
 #' in the TADA.ResultMeasureValueDataTypes.Flag column, or NA in the
-#' TADA.ResultMeasureValue column. In addition, this function removes results
-#' with QA/QC ActivityTypeCode's. This function also removes any columns not
-#' required for TADA workflow where all values are equal to NA. It provides a
-#' warning message identifying any TADA required columns containing only NA
-#' values.
+#' TADA.ResultMeasureValue column. In addition, this function also removes or
+#' flags results with QA/QC ActivityTypeCodes. This function also removes any
+#' columns not required for TADA workflow where all values are equal to NA.
+#' It provides a warning message identifying any TADA required columns
+#' containing only NA values which were removed.
 #'
 #' @param .data TADA dataframe
+#' @param clean Boolean argument. When clean = TRUE, rows where the result
+#' value is not numeric are removed. When clean = FALSE, rows with non-numeric
+#' result values are flagged with a removal reason in the new
+#' TADA.AutoFilter.Flag column.
 #'
-#' @return .data with rows non-quantitative and QA/QC results removed
+#' @return .data with rows non-quantitative and QA/QC results removed or
+#' flagged.
 #'
 #' @export
 #'

--- a/man/TADA_AutoFilter.Rd
+++ b/man/TADA_AutoFilter.Rd
@@ -4,32 +4,19 @@
 \alias{TADA_AutoFilter}
 \title{AutoFilter}
 \usage{
-TADA_AutoFilter(.data, clean = FALSE)
+TADA_AutoFilter(.data)
 }
 \arguments{
 \item{.data}{TADA dataframe}
-
-\item{clean}{Boolean argument. When clean = TRUE, rows where the result
-value is not numeric are removed. When clean = FALSE, rows with non-numeric
-result values are flagged with a removal reason in the new
-TADA.AutoFilter.Flag column. Default is clean = FALSE.}
 }
 \value{
-.data with rows non-quantitative and QA/QC results removed or
-flagged.
+.data with any non-required columns containing only NA values
+removed.
 }
 \description{
-This function removes or flags rows where the result value is not numeric to
-prepare a dataframe for quantitative analyses. Ideally, this function should
-be run after other data cleaning, QA/QC, and harmonization steps are
-completed using other TADA package functions, or manually. Specifically,
-this function removes rows with "Text" and "NA - Not Available"
-in the TADA.ResultMeasureValueDataTypes.Flag column, or NA in the
-TADA.ResultMeasureValue column. In addition, this function also removes or
-flags results with QA/QC ActivityTypeCodes. This function also removes any
-columns not required for TADA workflow where all values are equal to NA.
-It provides a warning message identifying any TADA required columns
-containing only NA values which were removed.
+This function also removes any columns not required for the TADA workflow
+where all values are equal to NA. It provides a warning message identifying
+any TADA required columns containing only NA values.
 }
 \examples{
 TADA_filtered <- TADA_AutoFilter(Data_Nutrients_UT)

--- a/man/TADA_AutoFilter.Rd
+++ b/man/TADA_AutoFilter.Rd
@@ -4,26 +4,32 @@
 \alias{TADA_AutoFilter}
 \title{AutoFilter}
 \usage{
-TADA_AutoFilter(.data)
+TADA_AutoFilter(.data, clean = FALSE)
 }
 \arguments{
 \item{.data}{TADA dataframe}
+
+\item{clean}{Boolean argument. When clean = TRUE, rows where the result
+value is not numeric are removed. When clean = FALSE, rows with non-numeric
+result values are flagged with a removal reason in the new
+TADA.AutoFilter.Flag column. Default is clean = FALSE.}
 }
 \value{
-.data with rows non-quantitative and QA/QC results removed
+.data with rows non-quantitative and QA/QC results removed or
+flagged.
 }
 \description{
-This function removes rows where the result value is not numeric to
+This function removes or flags rows where the result value is not numeric to
 prepare a dataframe for quantitative analyses. Ideally, this function should
 be run after other data cleaning, QA/QC, and harmonization steps are
 completed using other TADA package functions, or manually. Specifically,
 this function removes rows with "Text" and "NA - Not Available"
 in the TADA.ResultMeasureValueDataTypes.Flag column, or NA in the
-TADA.ResultMeasureValue column. In addition, this function removes results
-with QA/QC ActivityTypeCode's. This function also removes any columns not
-required for TADA workflow where all values are equal to NA. It provides a
-warning message identifying any TADA required columns containing only NA
-values.
+TADA.ResultMeasureValue column. In addition, this function also removes or
+flags results with QA/QC ActivityTypeCodes. This function also removes any
+columns not required for TADA workflow where all values are equal to NA.
+It provides a warning message identifying any TADA required columns
+containing only NA values which were removed.
 }
 \examples{
 TADA_filtered <- TADA_AutoFilter(Data_Nutrients_UT)

--- a/man/TADA_ConvertSpecialChars.Rd
+++ b/man/TADA_ConvertSpecialChars.Rd
@@ -4,7 +4,13 @@
 \alias{TADA_ConvertSpecialChars}
 \title{TADA_ConvertSpecialChars}
 \usage{
-TADA_ConvertSpecialChars(.data, col, percent.ave = TRUE)
+TADA_ConvertSpecialChars(
+  .data,
+  col,
+  percent.ave = TRUE,
+  clean = FALSE,
+  flaggedonly = FALSE
+)
 }
 \arguments{
 \item{.data}{A TADA profile object}
@@ -14,6 +20,13 @@ TADA_ConvertSpecialChars(.data, col, percent.ave = TRUE)
 \item{percent.ave}{Boolean argument; default is percent.ave = TRUE. When
 clean = TRUE, any percent range values will be averaged. When
 percent.ave = FALSE, percent range values are not averaged, but are flagged.}
+
+\item{clean}{Boolean argument; removes non-numeric result values from the
+data frame when clean = TRUE. Default is clean = FALSE.}
+
+\item{flaggedonly}{Boolean argument; filters dataframe to show only
+non-numeric result values when flaggedonly = TRUE. Default is flaggedonly
+= FALSE.}
 }
 \value{
 Returns the original dataframe with two new columns: the input column
@@ -35,7 +48,10 @@ converting a result value to numeric. Result values in the format # - # are
 converted to an average of the two numbers. Result values
 containing any other text or non-numeric characters become NA in
 the newly created "TADA.COLUMN NAME" and labeled accordingly in "TADA.COLUMN
-NAME DataTypes.Flag".
+NAME DataTypes.Flag". When clean = TRUE, rows that cannot be converted to
+numeric are removed. When clean = FALSE, no rows are removed. Default is
+clean = FALSE. When flaggedonly = TRUE, data frame is filtered to show only
+rows with non-numeric result values. Default is flaggedonly = FALSE.
 }
 \examples{
 HandleSpecialChars_ResultMeasureValue <-


### PR DESCRIPTION
Added a "clean" option for TADA_AutoFilter. Now clean = FALSE means that no rows are removed. Instead,, a TADA.AutoFilter.Flag column is added. When clean = TRUE, the results identified by the function are removed.

I was not sure where to add the new flag column in RequiredCols.R. Currently it is that last item in the Result Quality section.