### PR TITLE
Fix consolidated depth and depth flag bug

### DIFF
--- a/R/DepthProfile.R
+++ b/R/DepthProfile.R
@@ -209,7 +209,13 @@ TADA_FlagDepthCategory <- function(.data, bycategory = "no", bottomvalue = 2, su
       dplyr::select(-ARD_Category, -DepthsPerGroup)
 
     if (depth.count == 0) {
-      print(paste("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available, TADA_FlagDepthCategory cannot be used on this data set.", sep = ""))
+      print(paste0("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. ",
+                  "TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added."))
+
+      .data <- .data %>%
+        dplyr::mutate(TADA.DepthCategory.Flag = NA,
+                      TADA.ConsolidatedDepth = NA) %>%
+        TADA_OrderCols()
 
       return(.data)
     }

--- a/R/DepthProfile.R
+++ b/R/DepthProfile.R
@@ -208,10 +208,9 @@ TADA_FlagDepthCategory <- function(.data, bycategory = "no", bottomvalue = 2, su
       ) %>%
       dplyr::select(-ARD_Category, -DepthsPerGroup)
   }
-  
+
   if (depth.count == 0) {
-    print(paste0("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. ",
-                "TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added."))
+    print("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added.")
 
     .data <- .data %>%
       dplyr::mutate(TADA.DepthCategory.Flag = as.character(NA),
@@ -220,7 +219,7 @@ TADA_FlagDepthCategory <- function(.data, bycategory = "no", bottomvalue = 2, su
 
     return(.data)
   }
-  
+
 
   if (clean == TRUE) {
     .data <- .data %>%

--- a/R/DepthProfile.R
+++ b/R/DepthProfile.R
@@ -210,7 +210,7 @@ TADA_FlagDepthCategory <- function(.data, bycategory = "no", bottomvalue = 2, su
   }
 
   if (depth.count == 0) {
-    print("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added.")
+    print("TADA_FlagDepthCategory: No depth information was found in the dataset. The columns TADA.DepthCategory.Flag and TADA.ConsolidatedDepth are being added and populated with NA values.")
 
     .data <- .data %>%
       dplyr::mutate(TADA.DepthCategory.Flag = as.character(NA),

--- a/R/DepthProfile.R
+++ b/R/DepthProfile.R
@@ -207,19 +207,20 @@ TADA_FlagDepthCategory <- function(.data, bycategory = "no", bottomvalue = 2, su
         TADA.DepthCategory.Flag = ifelse(is.na(TADA.DepthCategory.Flag), "Not enough depth info to determine category", TADA.DepthCategory.Flag)
       ) %>%
       dplyr::select(-ARD_Category, -DepthsPerGroup)
-
-    if (depth.count == 0) {
-      print(paste0("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. ",
-                  "TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added."))
-
-      .data <- .data %>%
-        dplyr::mutate(TADA.DepthCategory.Flag = NA,
-                      TADA.ConsolidatedDepth = NA) %>%
-        TADA_OrderCols()
-
-      return(.data)
-    }
   }
+  
+  if (depth.count == 0) {
+    print(paste0("TADA_FlagDepthCategory: checking data set for depth values. No results have depth values available. ",
+                "TADA.DepthCategory.Flag and TADA.ConsolidatedDepth columns filled with NA have been added."))
+
+    .data <- .data %>%
+      dplyr::mutate(TADA.DepthCategory.Flag = as.character(NA),
+                    TADA.ConsolidatedDepth = as.numeric(NA)) %>%
+      TADA_OrderCols()
+
+    return(.data)
+  }
+  
 
   if (clean == TRUE) {
     .data <- .data %>%


### PR DESCRIPTION
When a data set had no depth data available, the additional columns, TADA.DepthCategory.Flag and TADA.ConsolidatedDepth, were not added. This created problems in some workflows. This fix adds the two columns (filled with NA) when a data set has no depth data available.