### PR TITLE
Updates to mod3 functions and vignettes

### DIFF
--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -923,6 +923,7 @@ TADA_UpdateATTAINSAUMLCrosswalk <- function(org_id = NULL,
 #'
 TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assign = c("None", "All", "Org"),
                                 excel = FALSE, overwrite = FALSE) {
+  # argument input selection for auto_assign
   auto_assign <- match.arg(auto_assign)
 
   # Return an empty dataframe with column names only if a user does not define any arg inputs.
@@ -964,7 +965,7 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
     # Allows for users to crosswalk parameters by multiple orgs.
     org_id <- as.list(org_id)
 
-    # If  more than 1 org, it will create n duplicate rows for each TADA.ComparableDataIdentifier.
+    # If more than 1 org, it will create n duplicate rows for each TADA.ComparableDataIdentifier.
     if (length(org_id) > 1) {
       print(paste0(
         "TADA.CreateParamRef: More than one org_name was defined in your dataframe. ",
@@ -1087,7 +1088,11 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
           TADA.CharacteristicName, TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier,
           ATTAINS.ParameterName # , EPA304A.PollutantName
         ) %>%
-        dplyr::left_join(ATTAINSParameterWQPCharRef, by = c("TADA.CharacteristicName" = "CharacteristicName"), relationship = "many-to-many") %>%
+        dplyr::left_join(
+          ATTAINSParameterWQPCharRef, 
+          by = c("TADA.CharacteristicName" = "CharacteristicName"), 
+          relationship = "many-to-many"
+          ) %>%
         dplyr::mutate(ATTAINS.ParameterName = ATTAINS.ParameterName.y) %>%
         dplyr::select(
           TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier,
@@ -1165,69 +1170,21 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
             "No Crosswalk was provided and no exact matches were found for this organization."
           )
         ) %>%
+        dplyr::filter(!is.na(ATTAINS.ParameterName)) %>%
         dplyr::distinct()
     }
 
     # User provides their own user supplied parameter crosswalk
     if (!is.null(paramRef)) {
-      # Identifies NEW rows in your current CreateParamRef data frame that are missing from your paramRef input -
-      # i.e. current WQP Characteristics that you have not defined a crosswalk for
-      Flag1 <- CreateParamRef %>%
-        # anti_join will identify observations that exist in your 1st data frame, but not in the 2nd data frame.
-        dplyr::anti_join(
-          paramRef,
-          by =
-            c(
-              "TADA.ComparableDataIdentifier", "ATTAINS.OrganizationIdentifier"
-              # "ATTAINS.ParameterName", ATTAINS.FlagParameterName) # Exclude any dynamic values or possible NAs
-            )
-        ) %>%
-        dplyr::mutate(
-          Flag.ParameterInput =
-            "Suspect: Your paramRef argument did not include this TADA.ComparableDataIdentifier. Please ensure this is not a new WQP Characteristic Name entry that needs to be crosswalked."
-        )
-
-      # identifies if a user has MODIFIED any ATTAINS.ParameterName values by TADA.ComparableDataIdentifier and ATTAINS.OrganizationIdentifier
-      Flag2 <- paramRef %>%
-        dplyr::anti_join(
-          CreateParamRef,
-          by = c(
-            "TADA.ComparableDataIdentifier", "ATTAINS.ParameterName", "ATTAINS.OrganizationIdentifier"
-          )
-        ) %>%
-        dplyr::mutate(
-          Flag.ParameterInput =
-            "This ATTAINS.ParameterName crosswalk was MODIFIED by your input(s) for this TADA.ComparableDataIdentifier."
-        ) %>%
-        dplyr::mutate(
-          ATTAINS.FlagParameterName = dplyr::case_when(
-            ATTAINS.ParameterName == "No parameter match for TADA.ComparableDataIdentifier" | is.na(ATTAINS.ParameterName) ~
-              "No parameter crosswalk provided for TADA.ComparableDataIdentifier. Parameter will not be used for assessment.",
-            !ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName ~
-              "Parameter name is not included in ATTAINS, contact ATTAINS to add parameter name to Domain List.",
-            ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName & !paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
-              "Parameter name is listed as a prior cause in ATTAINS, but not for this organization.",
-            paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
-              "Parameter name is listed as a prior cause in ATTAINS for this organization."
-          )
-        )
-
-      CreateParamRef <- paramRef %>%
-        dplyr::select("TADA.ComparableDataIdentifier", "ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName") %>%
-        dplyr::full_join(
-          Flag1 %>%
-            dplyr::full_join(
-              Flag2,
-              by =
-                c(
-                  "TADA.ComparableDataIdentifier", "ATTAINS.OrganizationIdentifier",
-                  "ATTAINS.ParameterName", "ATTAINS.FlagParameterName", "Flag.ParameterInput"
-                )
-            ),
-          by = c("TADA.ComparableDataIdentifier", "ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName")
-        ) %>%
-        dplyr::mutate(Flag.ParameterInput = dplyr::if_else(is.na(ATTAINS.ParameterName), NA, Flag.ParameterInput)) %>%
-        dplyr::rows_patch(CreateParamRef, by = "TADA.ComparableDataIdentifier") %>%
+      paramRef <- paramRef %>% 
+        dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %>%
+        dplyr::mutate(Flag.ParameterInput = "This crosswalk was provided through a user supplied table") %>% 
+        dplyr::filter(!is.na(ATTAINS.ParameterName))
+      
+      CreateParamRef <- CreateParamRef %>% 
+        dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName, Flag.ParameterInput) %>%
+        dplyr::filter(!TADA.ComparableDataIdentifier %in% paramRef$TADA.ComparableDataIdentifier) %>% 
+        dplyr::bind_rows(paramRef[,c("ATTAINS.OrganizationIdentifier", "TADA.ComparableDataIdentifier", "ATTAINS.ParameterName", "Flag.ParameterInput")]) %>%
         dplyr::mutate(
           ATTAINS.FlagParameterName = dplyr::case_when(
             ATTAINS.ParameterName == "Not Applicable for Analysis." | is.na(ATTAINS.ParameterName) ~
@@ -1243,11 +1200,37 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
         dplyr::select(
           TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName,
           ATTAINS.FlagParameterName, Flag.ParameterInput
-        ) %>%
-        dplyr::distinct()
-
-      # remove intermediate object Flag1
-      rm(Flag1, Flag2)
+        ) 
+        
+        
+        # paramRef %>% 
+        # dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %>% 
+        # dplyr::full_join(
+        #   CreateParamRef, 
+        #   by = dplyr::join_by(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier)) %>% 
+        # dplyr::mutate(
+        #   Flag.ParameterInput = dplyr::if_else(
+        #     paste(TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %in% paste(paramRef$TADA.ComparableDataIdentifier, paramRef$ATTAINS.ParameterName), 
+        #       "This crosswalk was provided through a user supplied table", 
+        #       Flag.ParameterInput
+        #     )
+        #   ) %>%
+        # dplyr::mutate(
+        #   ATTAINS.FlagParameterName = dplyr::case_when(
+        #     ATTAINS.ParameterName == "Not Applicable for Analysis." | is.na(ATTAINS.ParameterName) ~
+        #       "No ATTAINS.ParameterName crosswalk provided for TADA.ComparableDataIdentifier. Parameter will not be used for assessment.",
+        #     !ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName ~
+        #       "Parameter name is not included in ATTAINS, contact ATTAINS to add ATTAINS.ParameterName name to Domain List.",
+        #     ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName & !paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
+        #       "Parameter name is listed as a prior cause in ATTAINS, but not for this organization.",
+        #     paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
+        #       "Parameter name is listed as a prior cause in ATTAINS for this organization"
+        #   )
+        # ) %>%
+        # dplyr::select(
+        #   TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName,
+        #   ATTAINS.FlagParameterName, Flag.ParameterInput
+        # ) 
     }
 
     # Excel ref files to be stored in the Downloads folder location.
@@ -1866,7 +1849,7 @@ TADA_CreateUseParamRef <- function(.data, org_id = NULL, paramRef = NULL, usePar
       if ("IncludeOrExclude" %in% names(useParamRef)) {
         useParamRef <- useParamRef %>%
           dplyr::select(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName, ATTAINS.UseName, IncludeOrExclude) %>%
-          dplyr::left_join(paramRef, by = c("ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName", "IncludeOrExclude"))
+          dplyr::left_join(paramRef, by = c("ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName"))
       } else {
         print("IncludeOrExclude was not found as a column name in your user supplied, assuming all parameter and uses are applicable for your analysis.")
         useParamRef <- useParamRef %>%

--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -1026,7 +1026,7 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
 
     # Pulls in all unique combinations of TADA.ComparableDataIdentifier in user's dataframe.
     TADA_param <- dplyr::distinct(
-      .data[, c("TADA.ComparableDataIdentifier")]
+      .data[, c("TADA.ComparableDataIdentifier"), drop = FALSE]
     ) %>%
       dplyr::distinct() %>%
       dplyr::mutate(ATTAINS.OrganizationIdentifier = NA_character_) %>%
@@ -1036,10 +1036,10 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
       ) %>%
       dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier)) %>%
       dplyr::left_join(
-        .data[,c("TADA.ComparableDataIdentifier", "TADA.CharacteristicName")],
+        .data[, c("TADA.ComparableDataIdentifier", "TADA.CharacteristicName")],
         relationship = "many-to-many"
-        ) %>% 
-      distinct()
+      ) %>%
+      dplyr::distinct()
 
     # Pulls in all domain values of parameter and use names in ATTAINS.
     ATTAINS_param_all <- utils::read.csv(
@@ -1096,10 +1096,10 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
           ATTAINS.ParameterName # , EPA304A.PollutantName
         ) %>%
         dplyr::left_join(
-          ATTAINSParameterWQPCharRef, 
-          by = c("TADA.CharacteristicName" = "CharacteristicName"), 
+          ATTAINSParameterWQPCharRef,
+          by = c("TADA.CharacteristicName" = "CharacteristicName"),
           relationship = "many-to-many"
-          ) %>%
+        ) %>%
         dplyr::mutate(ATTAINS.ParameterName = ATTAINS.ParameterName.y) %>%
         dplyr::select(
           TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier,
@@ -1183,15 +1183,15 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
 
     # User provides their own user supplied parameter crosswalk
     if (!is.null(paramRef)) {
-      paramRef <- paramRef %>% 
+      paramRef <- paramRef %>%
         dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %>%
-        dplyr::mutate(Flag.ParameterInput = "This crosswalk was provided through a user supplied table") %>% 
+        dplyr::mutate(Flag.ParameterInput = "This crosswalk was provided through a user supplied table") %>%
         dplyr::filter(!is.na(ATTAINS.ParameterName))
-      
-      CreateParamRef <- CreateParamRef %>% 
+
+      CreateParamRef <- CreateParamRef %>%
         dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName, Flag.ParameterInput) %>%
-        dplyr::filter(!TADA.ComparableDataIdentifier %in% paramRef$TADA.ComparableDataIdentifier) %>% 
-        dplyr::bind_rows(paramRef[,c("ATTAINS.OrganizationIdentifier", "TADA.ComparableDataIdentifier", "ATTAINS.ParameterName", "Flag.ParameterInput")]) %>%
+        dplyr::filter(!TADA.ComparableDataIdentifier %in% paramRef$TADA.ComparableDataIdentifier) %>%
+        dplyr::bind_rows(paramRef[, c("ATTAINS.OrganizationIdentifier", "TADA.ComparableDataIdentifier", "ATTAINS.ParameterName", "Flag.ParameterInput")]) %>%
         dplyr::mutate(
           ATTAINS.FlagParameterName = dplyr::case_when(
             ATTAINS.ParameterName == "Not Applicable for Analysis." | is.na(ATTAINS.ParameterName) ~
@@ -1207,37 +1207,37 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
         dplyr::select(
           TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName,
           ATTAINS.FlagParameterName, Flag.ParameterInput
-        ) 
-        
-        
-        # paramRef %>% 
-        # dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %>% 
-        # dplyr::full_join(
-        #   CreateParamRef, 
-        #   by = dplyr::join_by(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier)) %>% 
-        # dplyr::mutate(
-        #   Flag.ParameterInput = dplyr::if_else(
-        #     paste(TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %in% paste(paramRef$TADA.ComparableDataIdentifier, paramRef$ATTAINS.ParameterName), 
-        #       "This crosswalk was provided through a user supplied table", 
-        #       Flag.ParameterInput
-        #     )
-        #   ) %>%
-        # dplyr::mutate(
-        #   ATTAINS.FlagParameterName = dplyr::case_when(
-        #     ATTAINS.ParameterName == "Not Applicable for Analysis." | is.na(ATTAINS.ParameterName) ~
-        #       "No ATTAINS.ParameterName crosswalk provided for TADA.ComparableDataIdentifier. Parameter will not be used for assessment.",
-        #     !ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName ~
-        #       "Parameter name is not included in ATTAINS, contact ATTAINS to add ATTAINS.ParameterName name to Domain List.",
-        #     ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName & !paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
-        #       "Parameter name is listed as a prior cause in ATTAINS, but not for this organization.",
-        #     paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
-        #       "Parameter name is listed as a prior cause in ATTAINS for this organization"
-        #   )
-        # ) %>%
-        # dplyr::select(
-        #   TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName,
-        #   ATTAINS.FlagParameterName, Flag.ParameterInput
-        # ) 
+        )
+
+
+      # paramRef %>%
+      # dplyr::select(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %>%
+      # dplyr::full_join(
+      #   CreateParamRef,
+      #   by = dplyr::join_by(ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier)) %>%
+      # dplyr::mutate(
+      #   Flag.ParameterInput = dplyr::if_else(
+      #     paste(TADA.ComparableDataIdentifier, ATTAINS.ParameterName) %in% paste(paramRef$TADA.ComparableDataIdentifier, paramRef$ATTAINS.ParameterName),
+      #       "This crosswalk was provided through a user supplied table",
+      #       Flag.ParameterInput
+      #     )
+      #   ) %>%
+      # dplyr::mutate(
+      #   ATTAINS.FlagParameterName = dplyr::case_when(
+      #     ATTAINS.ParameterName == "Not Applicable for Analysis." | is.na(ATTAINS.ParameterName) ~
+      #       "No ATTAINS.ParameterName crosswalk provided for TADA.ComparableDataIdentifier. Parameter will not be used for assessment.",
+      #     !ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName ~
+      #       "Parameter name is not included in ATTAINS, contact ATTAINS to add ATTAINS.ParameterName name to Domain List.",
+      #     ATTAINS.ParameterName %in% ATTAINS_param_all$ATTAINS.ParameterName & !paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
+      #       "Parameter name is listed as a prior cause in ATTAINS, but not for this organization.",
+      #     paste(ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName) %in% paste(ATTAINS_param_all$ATTAINS.OrganizationIdentifier, ATTAINS_param_all$ATTAINS.ParameterName) ~
+      #       "Parameter name is listed as a prior cause in ATTAINS for this organization"
+      #   )
+      # ) %>%
+      # dplyr::select(
+      #   TADA.ComparableDataIdentifier, ATTAINS.OrganizationIdentifier, ATTAINS.ParameterName,
+      #   ATTAINS.FlagParameterName, Flag.ParameterInput
+      # )
     }
 
     # Excel ref files to be stored in the Downloads folder location.

--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -962,9 +962,6 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
       stop("TADA.CreateParamRef: org_id must be a character vector")
     }
 
-    # Allows for users to crosswalk parameters by multiple orgs.
-    org_id <- as.list(org_id)
-
     # If more than 1 org, it will create n duplicate rows for each TADA.ComparableDataIdentifier.
     if (length(org_id) > 1) {
       print(paste0(
@@ -1029,10 +1026,20 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
 
     # Pulls in all unique combinations of TADA.ComparableDataIdentifier in user's dataframe.
     TADA_param <- dplyr::distinct(
-      .data[, c("TADA.CharacteristicName", "TADA.ComparableDataIdentifier")]
+      .data[, c("TADA.ComparableDataIdentifier")]
     ) %>%
-      tidyr::uncount(weights = length(org_id)) %>%
-      dplyr::mutate(ATTAINS.OrganizationIdentifier = as.character(rep(org_id, nrow(.) / length(org_id))))
+      dplyr::distinct() %>%
+      dplyr::mutate(ATTAINS.OrganizationIdentifier = NA_character_) %>%
+      tidyr::complete(
+        TADA.ComparableDataIdentifier,
+        ATTAINS.OrganizationIdentifier = org_id
+      ) %>%
+      dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier)) %>% 
+      dplyr::left_join(
+        .data[,c("TADA.ComparableDataIdentifier", "TADA.CharacteristicName")],
+        relationship = "many-to-many"
+        ) %>% 
+      distinct()
 
     # Pulls in all domain values of parameter and use names in ATTAINS.
     ATTAINS_param_all <- utils::read.csv(

--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -1034,7 +1034,7 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
         TADA.ComparableDataIdentifier,
         ATTAINS.OrganizationIdentifier = org_id
       ) %>%
-      dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier)) %>% 
+      dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier)) %>%
       dplyr::left_join(
         .data[,c("TADA.ComparableDataIdentifier", "TADA.CharacteristicName")],
         relationship = "many-to-many"

--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -1474,7 +1474,6 @@ TADA_CreateParamRef <- function(.data, org_id = NULL, paramRef = NULL, auto_assi
 #' argument input, by joining the ATTAINS.WaterType of the AUs defined in
 #' your useAURef to the ATTAINS.WaterType found from ATTAINS Expert Query.
 #'
-#'
 #' Otherwise, users can still
 #' proceed by overriding the data validation by value pasting in Excel.
 #' Users will be warned in the ATTAINS.FlagUseName column if they choose to

--- a/R/ATTAINSRefTables.R
+++ b/R/ATTAINSRefTables.R
@@ -19,7 +19,6 @@ ATTAINSParamToWQPCharRef_Cached <- NULL
 #'
 #' @export
 TADA_GetATTAINSParamToWQPCharRef <- function(charAliasType = c("All", "ATTAINS")) {
-
   charAliasType <- match.arg(charAliasType)
 
   # Pull in WQX Char Alias table.
@@ -43,24 +42,24 @@ TADA_GetATTAINSParamToWQPCharRef <- function(charAliasType = c("All", "ATTAINS")
   rm(temp_zip, temp_dir, csv_file_path)
 
   # retrieve the ATTAINS parameter domain value from rExpertQuery
-  ATTAINS.raw <-  spsUtil::quiet(rExpertQuery::EQ_DomainValues("param_name"))
+  ATTAINS.raw <- spsUtil::quiet(rExpertQuery::EQ_DomainValues("param_name"))
 
   ATTAINSParamRef <- ATTAINS.raw[, "name", drop = FALSE]
 
   # Create the initial ATTAINS param to WQX char crosswalk
-  if(charAliasType == "ATTAINS") {
+  if (charAliasType == "ATTAINS") {
     WQX_char_alias_filtered <- dplyr::filter(WQX_char_alias_filtered, Alias.Type.Name == "ATTAINS.PARAMETER")
 
     ATTAINSWQX <- ATTAINSParamRef |>
-      dplyr::left_join(WQX_char_alias_filtered, by = c("name"  = "Alias.Name")) |>
+      dplyr::left_join(WQX_char_alias_filtered, by = c("name" = "Alias.Name")) |>
       dplyr::select(CharacteristicName = Characteristic.Name, ATTAINS.ParameterName = name, Alias.Type.Name) |>
       dplyr::mutate(CharacteristicName = toupper(CharacteristicName)) |>
       dplyr::distinct()
   }
 
-  if(charAliasType == "All") {
+  if (charAliasType == "All") {
     ATTAINSWQX <- ATTAINSParamRef |>
-      dplyr::left_join(WQX_char_alias_filtered, by = c("name"  = "Alias.Name")) |>
+      dplyr::left_join(WQX_char_alias_filtered, by = c("name" = "Alias.Name")) |>
       dplyr::select(CharacteristicName = Characteristic.Name, ATTAINS.ParameterName = name, Alias.Type.Name) |>
       dplyr::mutate(CharacteristicName = toupper(CharacteristicName)) |>
       dplyr::distinct()
@@ -142,22 +141,21 @@ TADA_UpdateATTAINSParamToWQPCharRef <- function() {
 #'   displayPercent = TRUE,
 #'   ATTAINS.WQX.tolerance = 1.0,
 #'   WQX.ATTAINS.tolerance = 1.0
-#'   )
+#' )
 #'
 #' review_less_strict <- TADA_AdditionalCharAliasForReview(
 #'   displayPercent = TRUE,
 #'   ATTAINS.WQX.tolerance = 0.5,
 #'   WQX.ATTAINS.tolerance = 0.5
-#'   )
+#' )
 #'
 TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
                                               displayPercent = FALSE,
                                               ATTAINS.CST.tolerance = 1.00,
                                               CST.ATTAINS.tolerance = 1.00,
                                               ATTAINS.WQX.tolerance = 1.00,
-                                              WQX.ATTAINS.tolerance = 1.00
-) {
-  if(ATTAINS.CST.tolerance > 1.00 | CST.ATTAINS.tolerance > 1.00 | ATTAINS.WQX.tolerance > 1.00 | WQX.ATTAINS.tolerance > 1.00) {
+                                              WQX.ATTAINS.tolerance = 1.00) {
+  if (ATTAINS.CST.tolerance > 1.00 | CST.ATTAINS.tolerance > 1.00 | ATTAINS.WQX.tolerance > 1.00 | WQX.ATTAINS.tolerance > 1.00) {
     stop("One or more tolerance defined is greater than 1.00. Tolerance cannot exceed 100%.")
   }
 
@@ -170,12 +168,13 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   WQXCharacteristicRef <- raw.data |>
     dplyr::rename(
       CharacteristicName = Name,
-      Char_Flag = Domain.Value.Status) |>
+      Char_Flag = Domain.Value.Status
+    ) |>
     # select the columns of interest from the data frame.
     dplyr::select(CharacteristicName, Char_Flag, Comparable.Name, CAS.Number)
 
   # WQX has dashes in the CAS number, remove them to match CST CAS number
-  WQXCharacteristicRef$CAS.Number <- gsub("-","", WQXCharacteristicRef$CAS.Number)
+  WQXCharacteristicRef$CAS.Number <- gsub("-", "", WQXCharacteristicRef$CAS.Number)
 
   WQXCharacteristicRef2 <- WQXCharacteristicRef |>
     dplyr::mutate(
@@ -227,24 +226,26 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   # Find matches by WQX char and CAS with CST pollutants
   WQX_CST_CAS_Ref <- WQXCharacteristicRef |>
     dplyr::inner_join(CST, by = c("CAS.Number" = "CAS_NO")) |>
-    #dplyr::mutate(ATTAINS.ParameterName = STD_POLLUTANT_NAME) |>
+    # dplyr::mutate(ATTAINS.ParameterName = STD_POLLUTANT_NAME) |>
     dplyr::distinct()
 
   # Look for percent word matches
   temp_ATTAINS_WQX <- dplyr::right_join(WQXCharacteristicRef2, ATTAINSParamRef2, by = "name_words", relationship = "many-to-many") |>
     dplyr::distinct(CharacteristicName, name, name_words, .keep_all = TRUE) |>
     dplyr::group_by(CharacteristicName, name) |>
-    dplyr::count() |> dplyr::ungroup() |>
+    dplyr::count() |>
+    dplyr::ungroup() |>
     dplyr::group_by(name) |>
     dplyr::mutate(
-      percent_match_WQX = n/stringr::str_count(CharacteristicName, "\\S+"),
-      percent_match_ATTAINS_WQX = n/stringr::str_count(name, "\\S+")
+      percent_match_WQX = n / stringr::str_count(CharacteristicName, "\\S+"),
+      percent_match_ATTAINS_WQX = n / stringr::str_count(name, "\\S+")
     ) |>
     dplyr::slice_max(order_by = percent_match_WQX + percent_match_ATTAINS_WQX) |>
     dplyr::right_join(
-      WQXCharacteristicRef, by = "CharacteristicName",
+      WQXCharacteristicRef,
+      by = "CharacteristicName",
       relationship = "many-to-many"
-      ) |>
+    ) |>
     dplyr::filter(
       percent_match_WQX + percent_match_ATTAINS_WQX > 1
     )
@@ -253,10 +254,10 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   temp_ATTAINS_WQX <- temp_ATTAINS_WQX |>
     dplyr::group_by(CharacteristicName) |>
     dplyr::mutate(
-      percent_match_WQX = n/stringr::str_count(CharacteristicName, "\\S+"),
-      percent_match_ATTAINS_WQX = n/stringr::str_count(name, "\\S+")
+      percent_match_WQX = n / stringr::str_count(CharacteristicName, "\\S+"),
+      percent_match_ATTAINS_WQX = n / stringr::str_count(name, "\\S+")
     )
-    #dplyr::slice_max(order_by = percent_match_WQX + percent_match_ATTAINS_WQX )
+  # dplyr::slice_max(order_by = percent_match_WQX + percent_match_ATTAINS_WQX )
 
   # more aggressive (too strict, can lead to missed matches)
   temp_ATTAINS_WQX_Final <- temp_ATTAINS_WQX |>
@@ -268,17 +269,19 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   temp_ATTAINS_CST <- dplyr::right_join(CST2, ATTAINSParamRef2, by = "name_words", relationship = "many-to-many") |>
     dplyr::distinct(POLLUTANT_NAME, name, name_words, .keep_all = TRUE) |>
     dplyr::group_by(POLLUTANT_NAME, name) |>
-    dplyr::count() |> dplyr::ungroup() |>
+    dplyr::count() |>
+    dplyr::ungroup() |>
     dplyr::group_by(name) |>
     dplyr::mutate(
-      percent_match_CST = n/stringr::str_count(POLLUTANT_NAME, "\\S+"),
-      percent_match_ATTAINS_CST = n/stringr::str_count(name, "\\S+")
+      percent_match_CST = n / stringr::str_count(POLLUTANT_NAME, "\\S+"),
+      percent_match_ATTAINS_CST = n / stringr::str_count(name, "\\S+")
     ) |>
-    dplyr::slice_max(order_by = percent_match_CST + percent_match_ATTAINS_CST ) |>
+    dplyr::slice_max(order_by = percent_match_CST + percent_match_ATTAINS_CST) |>
     dplyr::right_join(
-      CST, by = "POLLUTANT_NAME",
+      CST,
+      by = "POLLUTANT_NAME",
       relationship = "many-to-many"
-      ) |>
+    ) |>
     dplyr::filter(
       percent_match_CST + percent_match_ATTAINS_CST > 1
     )
@@ -290,10 +293,10 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   temp_ATTAINS_CST <- temp_ATTAINS_CST |>
     dplyr::group_by(POLLUTANT_NAME) |>
     dplyr::mutate(
-      percent_match_CST = n/stringr::str_count(POLLUTANT_NAME, "\\S+"),
-      percent_match_ATTAINS_CST = n/stringr::str_count(name, "\\S+")
+      percent_match_CST = n / stringr::str_count(POLLUTANT_NAME, "\\S+"),
+      percent_match_ATTAINS_CST = n / stringr::str_count(name, "\\S+")
     )
-    #dplyr::slice_max(order_by = percent_match_CST + percent_match_ATTAINS_CST)
+  # dplyr::slice_max(order_by = percent_match_CST + percent_match_ATTAINS_CST)
 
   # more aggressive (too strict, can lead to missed matches)
   temp_ATTAINS_CST_Final <- temp_ATTAINS_CST |>
@@ -337,19 +340,19 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
   # remove intermediate variables
   rm(temp_ATTAINS_WQX, temp_ATTAINS_WQX_Final, temp_ATTAINS_CST, temp_ATTAINS_CST_Final)
 
-  if(includeCST == TRUE){
+  if (includeCST == TRUE) {
     # Additional ATTAINS to WQX matches using ATTAINS-WQX-CST-CAS matches using TADA methods.
     ATTAINSWQX_non_matched <- temp_final |>
       dplyr::filter(!is.na(CharacteristicName)) |>
       dplyr::anti_join(
         ATTAINSParamToWQPCharRef,
         by = c("ATTAINS.ParameterName", "CharacteristicName")
-        ) |>
-      #dplyr::select(ATTAINS.ParameterName, CharacteristicName, CAS.Number) |>
+      ) |>
+      # dplyr::select(ATTAINS.ParameterName, CharacteristicName, CAS.Number) |>
       dplyr::distinct()
   }
 
-  if(includeCST == FALSE){
+  if (includeCST == FALSE) {
     # Additional ATTAINS to WQX matches using ATTAINS-WQX-CST-CAS matches using TADA methods.
     ATTAINSWQX_non_matched <- temp_final |>
       dplyr::filter(!is.na(CharacteristicName)) |>
@@ -360,13 +363,13 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
         CAS.Number,
         percent_match_ATTAINS_WQX,
         percent_match_WQX
-        ) |>
+      ) |>
       dplyr::filter(!is.na(ATTAINS.ParameterName)) |>
-      #dplyr::mutate(TADA.Status == "Not Reviewed")
-    dplyr::distinct()
+      # dplyr::mutate(TADA.Status == "Not Reviewed")
+      dplyr::distinct()
   }
 
-  if(displayPercent == FALSE){
+  if (displayPercent == FALSE) {
     ATTAINSWQX_non_matched <- ATTAINSWQX_non_matched |>
       dplyr::select(-
         dplyr::any_of(c(
@@ -374,8 +377,7 @@ TADA_AdditionalCharAliasForReview <- function(includeCST = FALSE,
           "percent_match_CST",
           "percent_match_ATTAINS_WQX",
           "percent_match_WQX"
-          ))
-      )
+        )))
   }
 
   # remove intermediate variable

--- a/R/CriteriaMethods.R
+++ b/R/CriteriaMethods.R
@@ -297,7 +297,12 @@ TADA_DefineCriteriaMethodology <- function(.data,
       tidyr::uncount(weights = length(org_id)) %>%
       dplyr::select(-TADA.CharacteristicName) %>%
       dplyr::distinct() %>%
-      dplyr::mutate(ATTAINS.OrganizationIdentifier = as.character(rep(org_id, nrow(.) / length(org_id))))
+      dplyr::mutate(ATTAINS.OrganizationIdentifier = NA_character_) %>%
+      tidyr::complete(
+        TADA.ComparableDataIdentifier, 
+        ATTAINS.OrganizationIdentifier = org_id
+        ) %>%
+      dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier))
 
     # Will include all unique TADA Char/ComparableDataIdentifier to be shown in the criteria table
     MLSummaryRef <- TADA_param %>%

--- a/R/CriteriaMethods.R
+++ b/R/CriteriaMethods.R
@@ -177,7 +177,7 @@ TADA_DefineCriteriaMethodology <- function(.data,
   }
 
   # Invalid function input combos - supply one or the other.
-  if ( !is.null(MLSummaryRef) && !is.null(criteriaMethods) ) {
+  if (!is.null(MLSummaryRef) && !is.null(criteriaMethods)) {
     stop("TADA_DefineCriteriaMethodology: MLSummaryRef and criteriaMethods are both provided. You can only proceed with one (or none) of these options provided.")
   }
 
@@ -292,16 +292,14 @@ TADA_DefineCriteriaMethodology <- function(.data,
     unique_param <- unique(.data$TADA.CharacteristicName)
     # Pulls in all unique combinations of TADA.ComparableDataIdentifier in user's dataframe.
     TADA_param <- dplyr::distinct(
-      .data[, c("TADA.CharacteristicName", "TADA.ComparableDataIdentifier")]
+      .data[, c("TADA.ComparableDataIdentifier"), drop = FALSE]
     ) %>%
-      tidyr::uncount(weights = length(org_id)) %>%
-      dplyr::select(-TADA.CharacteristicName) %>%
       dplyr::distinct() %>%
       dplyr::mutate(ATTAINS.OrganizationIdentifier = NA_character_) %>%
       tidyr::complete(
-        TADA.ComparableDataIdentifier, 
+        TADA.ComparableDataIdentifier,
         ATTAINS.OrganizationIdentifier = org_id
-        ) %>%
+      ) %>%
       dplyr::filter(!is.na(ATTAINS.OrganizationIdentifier))
 
     # Will include all unique TADA Char/ComparableDataIdentifier to be shown in the criteria table
@@ -490,7 +488,7 @@ TADA_DefineCriteriaMethodology <- function(.data,
           DurationValue = as.numeric(NA), DurationUnit = as.character(NA), DurationMethod = as.character(NA),
           FreqValue = as.numeric(NA), FreqMethod = as.character(NA),
           # Data Sufficiency Columns
-          AssessPeriod = as.character(NA), AssessPeriodStartDate = as.Date(NA), AssessPeriodEndDate = as.Date(NA), 
+          AssessPeriod = as.character(NA), AssessPeriodStartDate = as.Date(NA), AssessPeriodEndDate = as.Date(NA),
           Season = as.character(NA), SeasonStartDate = as.Date(NA), SeasonEndDate = as.Date(NA),
           DistrCount = as.numeric(NA), DistrPeriod = as.character(NA), DistrMinSample = as.numeric(NA), Notes = as.character(NA)
         )

--- a/R/CriteriaMethods.R
+++ b/R/CriteriaMethods.R
@@ -300,7 +300,7 @@ TADA_DefineCriteriaMethodology <- function(.data,
 
     # Will include all unique TADA Char/ComparableDataIdentifier to be shown in the criteria table
     MLSummaryRef <- TADA_param %>%
-      dplyr::left_join(MLSummaryRef)
+      dplyr::full_join(MLSummaryRef)
     # }
 
     # # Commenting out all code related to updateRef for now. See https://github.com/USEPA/EPATADA/issues/667
@@ -484,7 +484,7 @@ TADA_DefineCriteriaMethodology <- function(.data,
           DurationValue = as.numeric(NA), DurationUnit = as.character(NA), DurationMethod = as.character(NA),
           FreqValue = as.numeric(NA), FreqMethod = as.character(NA),
           # Data Sufficiency Columns
-          AssessPeriod = as.character(NA), AssessPeriodStartDate = as.Date(NA), AssessPeriodEndDate = as.Date(NA), Season = as.character(NA),
+          AssessPeriod = as.character(NA), AssessPeriodStartDate = as.Date(NA), AssessPeriodEndDate = as.Date(NA), 
           Season = as.character(NA), SeasonStartDate = as.Date(NA), SeasonEndDate = as.Date(NA),
           DistrCount = as.numeric(NA), DistrPeriod = as.character(NA), DistrMinSample = as.numeric(NA), Notes = as.character(NA)
         )

--- a/R/CriteriaMethods.R
+++ b/R/CriteriaMethods.R
@@ -172,17 +172,18 @@ TADA_DefineCriteriaMethodology <- function(.data,
 
   # If user supplies criteria methods table, then auto_assign = T for any non-matched values
   if (!is.null(criteriaMethods)) {
+    print("A criteriaMethods table was provided. auto_assign will be set to 'TRUE' to determine any missing or non-matching inputs.")
     auto_assign <- TRUE
   }
 
   # Invalid function input combos - supply one or the other.
-  # if ( !is.null(MLSummaryRef) && !is.null(criteriaMethods) ) {
-  #   stop("TADA_DefineCriteriaMethodology: MLSummaryRef and criteriaMethods are both provided. You can only proceed with one (or none) of these options provided.")
-  # }
+  if ( !is.null(MLSummaryRef) && !is.null(criteriaMethods) ) {
+    stop("TADA_DefineCriteriaMethodology: MLSummaryRef and criteriaMethods are both provided. You can only proceed with one (or none) of these options provided.")
+  }
 
-  # Invalid function input combos - MLSummaryRef and autofill = TRUE cannot be used together
+  # Invalid function input combos - MLSummaryRef and auto_assign = TRUE cannot be used together
   if (!is.null(MLSummaryRef) && auto_assign == TRUE) {
-    stop("TADA_DefineCriteriaMethodology: MLSummaryRef is provided and autofill = TRUE are not valid function argument input combinations.")
+    stop("TADA_DefineCriteriaMethodology: MLSummaryRef is provided and auto_assign = TRUE are not valid function argument input combinations.")
   }
 
   # Generates a blank Criteria and Methods file.
@@ -585,22 +586,24 @@ TADA_DefineCriteriaMethodology <- function(.data,
 
     if (nrow(non_definedCriteria) > 0 && displayUniqueId == TRUE) {
       warning(paste0(
-        "Your user supplied criteriaMethods file contains ",
+        "Your user supplied criteriaMethods file is missing ",
         length(unique(non_definedCriteria$TADA.ComparableDataIdentifier)),
-        " unique TADA.ComparableDataIdentifier(s) without a valid ",
-        "ATTAINS.ParameterName crosswalk ",
-        "when compared to the domain value of ATTAINS from the prior ",
-        "ATTAINS assessment cycle for your organization(s). ",
+        " unique TADA.ComparableDataIdentifier(s) ",
+        ": ",
+        unique(non_definedCriteria$TADA.ComparableDataIdentifier),
+        " without an ATTAINS.ParameterName crosswalk ",
         "Please review these entries in your crosswalk or remove them/leave them unfilled if not applicable to analysis."
       ))
     }
 
     if (nrow(non_definedCriteria) > 0 && displayUniqueId == FALSE) {
       warning(paste0(
-        "Your user supplied criteriaMethods file contains ",
+        "Your user supplied criteriaMethods file is missing ",
         length(unique(non_definedCriteria$TADA.CharacteristicName)),
-        " unique TADA.CharacteristicName(s) without a valid ATTAINS.ParameterName crosswalk ",
-        "when compared to the domain value of ATTAINS from the prior ATTAINS assessment cycle for your organization(s). ",
+        " unique TADA.CharacteristicName(s) ",
+        ": ",
+        unique(non_definedCriteria$TADA.CharacteristicName),
+        " without an ATTAINS.ParameterName crosswalk ",
         "Please review these entries in your crosswalk or remove them/leave them unfilled if not applicable to analysis."
       ))
     }

--- a/R/CriteriaRefTables.R
+++ b/R/CriteriaRefTables.R
@@ -65,7 +65,7 @@ TADA_GetEPACSTRef <- function() {
       use_name = USE_CLASS_NAME_LOCATION_ETC, CRITERION_VALUE,
       CRITERIATYPEAQUAHUMHLTH, CRITERIATYPEFRESHSALTWATER,
       CRITERIATYPE_ACUTECHRONIC, CRITERIATYPE_WATERORG, UNIT_NAME
-    ) 
+    )
 
   # Remove intermediate variables
   rm(CST.begin, tada.char.ref, raw.data)
@@ -90,9 +90,9 @@ CriteriaSearchToolRef_Cached <- NULL
 
 #' Criteria Search Tool Reference Table
 #'
-#' This function downloads the latest criteria search tool from the EPA OST and 
-#' returns it. Before use, the downloaded data is cleaned and formatted as the 
-#' the initial ~200 rows contain the legend and data dictionary, which need to 
+#' This function downloads the latest criteria search tool from the EPA OST and
+#' returns it. Before use, the downloaded data is cleaned and formatted as the
+#' the initial ~200 rows contain the legend and data dictionary, which need to
 #' be removed.
 #'
 #' This function caches the table after it has been called once
@@ -101,33 +101,33 @@ CriteriaSearchToolRef_Cached <- NULL
 #' @return Updated sysdata.rda with updated ATTAINSParamToWQPCharRef object
 #'
 #' @export
-TADA_GetCriteriaSearchToolRef <- function(){
+TADA_GetCriteriaSearchToolRef <- function() {
   CST.raw <- openxlsx::read.xlsx("https://cfpub.epa.gov/wqsits/wqcsearch/criteria-search-tool-data.xlsx")
-  
+
   # Find the first row that has all values populated. This will indicate the column names of the CST data frame.
   # Note: Why not use a static row number? The CST may get new entries that may change the start of the data frames.
   first_filled_row_index <- which(rowSums(is.na(CST.raw)) == 0)[1]
-  
+
   # Extract our CST column names
-  CST.cols <- as.character(CST.raw[first_filled_row_index,])
-  
+  CST.cols <- as.character(CST.raw[first_filled_row_index, ])
+
   # remove rows with "legend" info (rows 1-201)
   CST <- CST.raw[-c(1:first_filled_row_index), ]
-  
+
   # assign column names to the new data frame
   names(CST) <- CST.cols
-  
+
   # filter the dataframe to just the CAS and pollutant numbers for our use case.
   CST <- CST |>
     dplyr::select(POLLUTANT_NAME, STD_POLLUTANT_NAME, CAS_NO) |>
     dplyr::distinct()
-  
+
   # save updated table in cache
   CriteriaSearchToolRef_Cached <- CST
-  
+
   # remove intermediate objects
   rm(CST.raw, first_filled_row_index, CST.cols)
-  
+
   return(CST)
 }
 

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -155,8 +155,11 @@ utils::globalVariables(c(
   "ATTAINS.OrganizationId", "MatchMessage", "Mismatch", "Ref.WaterType",
   "Alias.Type.Name", "CAS_NO CAS.Number", "Char_Flag.x", "Char_Flag.y",
   "Characteristic.Name", "STD_POLLUTANT_NAME", "name", "name_words",
-  "percent_match_ATTAINS", "percent_match_WQX",
-  "Characteristic", "WQXcharValRef"
+  "percent_match_ATTAINS", "percent_match_WQX", "Characteristic", "WQXcharValRef",  
+  "CAS.Number", "CAS_NO CharacteristicName.x", "CharacteristicName.y",
+  "Comparable.Name.x", "Comparable.Name.y", "POLLUTANT_NAME.x", "POLLUTANT_NAME.y",
+  "STD_POLLUTANT_NAME.x", "STD_POLLUTANT_NAME.y", "percent_match_ATTAINS_CST",
+  "percent_match_ATTAINS_WQX", "percent_match_CST"
 ))
 
 # global variables for tribal feature layers used in TADA_OverviewMap in Utilities.R

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -154,7 +154,7 @@ utils::globalVariables(c(
   "UniqueSpatialCriteria", "ATTAINS.WaterType.y", "DepthCategory", "User.WaterType",
   "ATTAINS.OrganizationId", "MatchMessage", "Mismatch", "Ref.WaterType",
   "Alias.Type.Name", "CAS_NO CAS.Number", "Char_Flag.x", "Char_Flag.y",
-  "Characteristic.Name", "STD_POLLUTANT_NAME", "name", "name_words", 
+  "Characteristic.Name", "STD_POLLUTANT_NAME", "name", "name_words",
   "percent_match_ATTAINS", "percent_match_WQX",
   "Characteristic", "WQXcharValRef"
 ))

--- a/man/TADA_AdditionalCharAliasForReview.Rd
+++ b/man/TADA_AdditionalCharAliasForReview.Rd
@@ -73,12 +73,12 @@ review_more_strict <- TADA_AdditionalCharAliasForReview(
   displayPercent = TRUE,
   ATTAINS.WQX.tolerance = 1.0,
   WQX.ATTAINS.tolerance = 1.0
-  )
+)
 
 review_less_strict <- TADA_AdditionalCharAliasForReview(
   displayPercent = TRUE,
   ATTAINS.WQX.tolerance = 0.5,
   WQX.ATTAINS.tolerance = 0.5
-  )
+)
 
 }

--- a/tests/testthat/test-ATTAINSCSTRefTables.R
+++ b/tests/testthat/test-ATTAINSCSTRefTables.R
@@ -7,7 +7,7 @@ test_that("Does the current TADA_GetATTAINSParamToWQPCharRef contain all ATTAINS
 
   # extract unique ATTAINS parameter names
   ref <- ATTAINS.raw[, "name"]
-  old <- utils::read.csv(system.file("extdata", "ATTAINSParamToWQPCharRef.csv", package = "EPATADA"))[,"ATTAINS.ParameterName"]
+  old <- utils::read.csv(system.file("extdata", "ATTAINSParamToWQPCharRef.csv", package = "EPATADA"))[, "ATTAINS.ParameterName"]
 
   expect_in(ref, old)
 })
@@ -21,7 +21,7 @@ test_that("Does the current TADA_GetCriteriaSearchToolRef contain all CST pollut
   first_filled_row_index <- which(rowSums(is.na(CST.raw)) == 0)[1]
 
   # Extract our CST column names
-  CST.cols <- as.character(CST.raw[first_filled_row_index,])
+  CST.cols <- as.character(CST.raw[first_filled_row_index, ])
 
   # remove rows with "legend" info (rows 1-201)
   CST <- CST.raw[-c(1:first_filled_row_index), ]
@@ -34,7 +34,7 @@ test_that("Does the current TADA_GetCriteriaSearchToolRef contain all CST pollut
     dplyr::select(POLLUTANT_NAME, STD_POLLUTANT_NAME, CAS_NO) %>%
     dplyr::distinct()
   ref <- CST$POLLUTANT_NAME
-  old <- utils::read.csv(system.file("extdata", "CriteriaSearchToolRef.csv", package = "EPATADA"))[,"POLLUTANT_NAME"]
+  old <- utils::read.csv(system.file("extdata", "CriteriaSearchToolRef.csv", package = "EPATADA"))[, "POLLUTANT_NAME"]
 
   expect_in(ref, old)
 })

--- a/vignettes/ExampleMod3CriteriaMethodsAltOptions.Rmd
+++ b/vignettes/ExampleMod3CriteriaMethodsAltOptions.Rmd
@@ -201,7 +201,7 @@ the excel file.
 MT.Criteria.blank <- TADA_DefineCriteriaMethodology(
   tada.MT.clean, # remove this as an arg input
   org_id = "MTDEQ", # can remove this too
-  # auto_assign = FALSE,
+  auto_assign = FALSE, displayUniqueId = TRUE,
   excel = FALSE
   # uncomment to run the excel file
   # excel = TRUE, overwrite = TRUE

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -581,12 +581,12 @@ and joined to an internal parameter and water type extraction from
 rExpertQuery to assign any new uses to parameters.
 
 ```{r useParamRef-with-useAURef}
-MT.UseParamRef.useAURef <- TADA_CreateUseParamRef(
+MT.UseParamRef.with.useAURef <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   paramRef = MT.ParamRef.Final,
   useAURef = Data_MT.UseAURef_Water, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
-  auto_assign = FALSE,
+  auto_assign = TRUE,
   excel = FALSE
 )
 ```
@@ -665,7 +665,7 @@ MT.UseParamRef.Final <- TADA_CreateUseParamRef(
 # Test if the two data frames are same or not.
 identical(MT.UseParamRef.Final[1:5], MT.UseParamRef.user.supplied.edit[1:5])
 
-TADA_TableExport(MT.useParamRef_Final)
+TADA_TableExport(MT.useParamRef.Final)
 ```
 
 remove intermediate variable, keep only the crosswalk table that we will
@@ -703,7 +703,7 @@ data, please choose displayNA = TRUE
 ```{r ML_Summary}
 MT.MLSummaryRef.ML <- TADA_CreateMLSummaryRef(
   .data = tada.MT.clean,
-  useParamRef = MT.UseParamRef.AutoAssign,
+  useParamRef = MT.UseParamRef.Final,
   org_id = "MTDEQ",
   displayNA = FALSE
 )
@@ -800,31 +800,15 @@ Note: Whenever a criteriaMethods argument input value is provided, users
 will be warned if there are additional WQP characteristics (or
 TADA.ComparableDataIdentifier - see argument input uniqueDataId =
 TRUE/FALSE in the R documentation for more information) that are not
-captured in their user supplied table.
+captured in their user supplied table. Thus, auto_assign defaults to
+TRUE even if it is specified as FALSE.
 
 ```{r user-supplied-output}
 MT.CriteriaMethods.user.supplied <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef.ML,
+  MLSummaryRef = NULL,
   criteriaMethods = criteria_table,
-  excel = FALSE
-)
-```
-
-Note: When a user provides a MLSummaryRef, it is assumed their criteria
-tables parameter crosswalk is based on the paramRef and useParamRef
-crosswalk done. However, whenever a criteriaMethods table is provided,
-all unique WQP Characteristic (or TADA.ComparableDataIdentifier) will be
-shown in the table.
-
-```{r step-by-step-output-with-displayUniqueId}
-MT.CriteriaMethods.User.Supplied2 <- TADA_DefineCriteriaMethodology(
-  .data = tada.MT.clean,
-  org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef.ML,
-  criteriaMethods = criteria_table,
-  displayUniqueId = TRUE,
   excel = FALSE
 )
 ```
@@ -833,10 +817,10 @@ You can append epa304a recommended standards (if there is one found for
 a TADA.CharacteristicName)
 
 ```{r append-epa304a-recommended-standards}
-MT.CriteriaMethods.User.Supplied3 <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.User.Supplied2 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef.ML,
+  MLSummaryRef = NULL,
   criteriaMethods = criteria_table,
   displayUniqueId = TRUE,
   epa304a = TRUE,
@@ -853,13 +837,13 @@ new fraction/speciations) are being queried in your most up to date WQP
 query and to allow you to determine if an assessment magnitude value
 should be developed.
 
-For our example, we will use MT.CriteriaMethods_User_Supplied3 and fill
+For our example, we will use MT.CriteriaMethods_User_Supplied2 and fill
 in the remaining blank PH magnitude values with a range between 6.5 and
 8.5 as MTDEQ criteria of interest.
 
 ```{r finalize-criteria-table}
 # We will fill in PH magnitude values for this example
-MT.CriteriaMethods.Final <- MT.CriteriaMethods.User.Supplied3 %>%
+MT.CriteriaMethods.Final <- MT.CriteriaMethods.User.Supplied2 %>%
   dplyr::mutate(MagnitudeValueLower = dplyr::case_when(
     grepl("PH_NONE_NONE_NONE", TADA.ComparableDataIdentifier) & ATTAINS.OrganizationIdentifier == "MTDEQ" ~ 6.5,
     TRUE ~ MagnitudeValueLower
@@ -876,6 +860,7 @@ We will supply this final crosswalk table to be reused and validated.
 MT.CriteriaMethods.Final2 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
+  MLSummaryRef = NULL,
   criteriaMethods = MT.CriteriaMethods.Final,
   displayUniqueId = TRUE,
   excel = FALSE

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(
   echo = TRUE,
   warning = FALSE,
   message = FALSE,
-  eval = FALSE
+  eval = TRUE
 )
 ```
 
@@ -84,7 +84,7 @@ remotes::install_github("USEPA/EPATADA",
 
 ```{r dev_install, results = 'hide', include = F}
 remotes::install_github("USEPA/EPATADA",
-  ref = "develop",
+  ref = "Updates-to-Mod3-Functions-and-Vignettes",
   dependencies = TRUE
 )
 ```

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -561,7 +561,7 @@ MT.UseParamRef.AutoAssign <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   paramRef = MT.ParamRef.Final,
-  #useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
+  # useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
   auto_assign = TRUE,
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -309,7 +309,7 @@ this crosswalk out.
 
 ```{r auto_assign-none}
 # create TADA parameter reference table for specified organization
-MT.ParamRef_None <- TADA_CreateParamRef(
+MT.ParamRef.None <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   auto_assign = "None",
@@ -329,7 +329,7 @@ in ATTAINS may be included in the assignments.
 
 ```{r auto_assign-All}
 # create TADA parameter reference table for specified organization
-MT.ParamRef_All <- TADA_CreateParamRef(
+MT.ParamRef.All <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   auto_assign = "All",
@@ -345,7 +345,7 @@ organization has used in the past.
 
 ```{r auto_assign-Org}
 # create TADA parameter reference table for specified organization
-MT.ParamRef_Org <- TADA_CreateParamRef(
+MT.ParamRef.Org <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   auto_assign = "Org",
@@ -381,14 +381,14 @@ name.
 #   excel = TRUE, overwrite = TRUE
 #   )
 
-ParamRef <- MT.ParamRef_None %>%
+ParamRef <- MT.ParamRef.None %>%
   dplyr::mutate(ATTAINS.ParameterName = dplyr::case_when(
     grepl("PH_NONE_NONE_NONE", TADA.ComparableDataIdentifier) ~ "PH",
     grepl("ESCHERICHIA COLI", TADA.ComparableDataIdentifier) ~ "ESCHERICHIA COLI (E. COLI)"
   )) %>%
   dplyr::bind_rows(data.frame(TADA.ComparableDataIdentifier = "PH_NONE_NONE_NONE", ATTAINS.ParameterName = "PH, HIGH", ATTAINS.OrganizationIdentifier = "MTDEQ"))
 
-MT.ParamRef_Manual <- TADA_CreateParamRef(
+MT.ParamRef.Manual <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
   paramRef = ParamRef,
@@ -407,10 +407,10 @@ will determine if any new WQX characteristic names are included in the
 TADA data frame and add additional rows to the crosswalk if needed.
 
 ```{r User-Supplied-ParamRef}
-MT.ParamRef_user_supplied <- TADA_CreateParamRef(
+MT.ParamRef.user.supplied <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Manual,
+  paramRef = MT.ParamRef.Manual,
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
@@ -427,19 +427,19 @@ query and to allow you to review how to handle these new additions.
 
 If new WQP characteristics (or new fraction/speciations) do show up,
 your user supplied 'paramRef' is prioritized over the 'auto_assign'
-argument inputs. Thus, the auto_assign option will allow you to fill in
-any remaining blank ATTAINS.ParameterName that you have not filled in
-but will not replace any cross walk that you have defined in your user
+argument inputs. The auto_assign option will allow you to fill in any
+remaining blank ATTAINS.ParameterName that you have not filled in but
+will not replace any cross walk that you have defined in your user
 supplied crosswalk. In our case, since each unique
 TADA.ComparableDataIdentifier was cross walked to an
 ATTAINS.ParameterName in the user supplied 'MT.ParamRef_user_supplied,
 this table will be the same.
 
 ```{r finalize-paramRef}
-MT.ParamRef_Final <- TADA_CreateParamRef(
+MT.ParamRef.Final <- TADA_CreateParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_user_supplied,
+  paramRef = MT.ParamRef.user.supplied,
   auto_assign = "All",
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
@@ -447,16 +447,16 @@ MT.ParamRef_Final <- TADA_CreateParamRef(
 )
 
 # Test if the two data frames are same or not.
-identical(MT.ParamRef_Final[1:4], MT.ParamRef_user_supplied[1:4])
+identical(MT.ParamRef.Final[1:4], MT.ParamRef.user.supplied[1:4])
 
-TADA_TableExport(MT.ParamRef_Final)
+TADA_TableExport(MT.ParamRef.Final)
 ```
 
 remove intermediate variable, keep only the crosswalk table that we will
 continue to use in the workflow.
 
 ```{r remove-intermediate-variables}
-rm(ParamRef, MT.ParamRef_All, MT.ParamRef_Manual, MT.ParamRef_None, MT.ParamRef_Org, MT.ParamRef_user_supplied)
+rm(ParamRef, MT.ParamRef.All, MT.ParamRef.Manual, MT.ParamRef.None, MT.ParamRef.Org, MT.ParamRef.user.supplied)
 ```
 
 # TADA_CreateUseParamRef() Basics
@@ -496,10 +496,10 @@ for in this current assessment/analysis cycle. Thus, the ATTAINS.UseName
 is left blank for "PH, HIGH".
 
 ```{r useparamref-Manual}
-MT.UseParamRef_Manual <- TADA_CreateUseParamRef(
+MT.UseParamRef.Manual <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Final,
+  paramRef = MT.ParamRef.Final,
   auto_assign = FALSE,
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
@@ -512,7 +512,7 @@ If desired, a user can manually assign "PH, HIGH" to any applicable uses
 reflect MTDEQ's criteria and assessment process).
 
 ```{r useparamref-Manual-Update}
-add_data <- data.frame(
+add.data <- data.frame(
   "ATTAINS.OrganizationIdentifier" = "MTDEQ",
   "ATTAINS.ParameterName" = rep("PH, HIGH", 2),
   "ATTAINS.UseName" = c(
@@ -522,16 +522,16 @@ add_data <- data.frame(
 )
 
 # The output of this will not reflect changes to the ATTAINS.FlagUseName column. To do so, we need to re run TADA_CreateUseParamRef() with UseParamRef = add_data as an argument input.
-UseParamRef <- MT.UseParamRef_Manual %>%
-  dplyr::left_join(add_data, by = c("ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName"), keep = FALSE) %>%
+UseParamRef <- MT.UseParamRef.Manual %>%
+  dplyr::left_join(add.data, by = c("ATTAINS.OrganizationIdentifier", "ATTAINS.ParameterName"), keep = FALSE) %>%
   dplyr::mutate(ATTAINS.UseName = dplyr::coalesce(ATTAINS.UseName.x, ATTAINS.UseName.y)) %>%
   dplyr::select(-c(ATTAINS.UseName.x, ATTAINS.UseName.y)) %>%
   dplyr::mutate(IncludeOrExclude = "Include")
 
 # PH will now reflect the changes
-MT.UseParamRef_Manual_Update <- TADA_CreateUseParamRef(
+MT.UseParamRef.Manual.Update <- TADA_CreateUseParamRef(
   tada.MT.clean,
-  paramRef = MT.ParamRef_Final,
+  paramRef = MT.ParamRef.Final,
   useParamRef = UseParamRef, # Edits were made to UseParamRef, updates flag column
   org_id = c("MTDEQ"),
   auto_assign = FALSE,
@@ -540,7 +540,7 @@ MT.UseParamRef_Manual_Update <- TADA_CreateUseParamRef(
   # excel = TRUE, overwrite = TRUE
 )
 
-TADA_TableExport(MT.UseParamRef_Manual_Update)
+TADA_TableExport(MT.UseParamRef.Manual.Update)
 ```
 
 ### Auto_assign Option
@@ -555,19 +555,19 @@ captured by the auto_assign method.
 
 ```{r useparamref-AutoAssign}
 # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
-utils::data(MT.UseAURef_with_WaterUseRef)
+utils::data(Data_MT.UseAURef_Water)
 
-MT.UseParamRef_AutoAssign <- TADA_CreateUseParamRef(
+MT.UseParamRef.AutoAssign <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Final,
-  useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
+  paramRef = MT.ParamRef.Final,
+  #useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
   auto_assign = TRUE,
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
-TADA_TableExport(MT.UseParamRef_AutoAssign)
+TADA_TableExport(MT.UseParamRef.AutoAssign)
 ```
 
 ### User has completed a Use to AU crosswalk
@@ -581,11 +581,11 @@ and joined to an internal parameter and water type extraction from
 rExpertQuery to assign any new uses to parameters.
 
 ```{r useParamRef-with-useAURef}
-MT.UseParamRef_with_useAURef <- TADA_CreateUseParamRef(
+MT.UseParamRef.useAURef <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Final,
-  useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
+  paramRef = MT.ParamRef.Final,
+  useAURef = Data_MT.UseAURef_Water, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
   auto_assign = FALSE,
   excel = FALSE
 )
@@ -620,13 +620,13 @@ consider for analysis.
 # Load the example MTDEQ criteria table
 load("C:/Users/kwong01/EPATADA/inst/extdata/criteria_table.rda")
 
-MT.UseParam_user_supplied <- dplyr::select(criteria_table, ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, TADA.CharacteristicName, ATTAINS.ParameterName, ATTAINS.UseName)
+MT.UseParam.user.supplied <- dplyr::select(criteria_table, ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, TADA.CharacteristicName, ATTAINS.ParameterName, ATTAINS.UseName)
 
-MT.UseParamRef_user_supplied_Edit <- TADA_CreateUseParamRef(
+MT.UseParamRef.user.supplied.edit <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Final,
-  useParamRef = MT.UseParam_user_supplied,
+  paramRef = MT.ParamRef.Final,
+  useParamRef = MT.UseParam.user.supplied,
   auto_assign = TRUE,
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
@@ -651,11 +651,11 @@ have not filled in but will not replace any cross walk that you have
 defined in your user supplied crosswalk.
 
 ```{r finalize-useParamRef}
-MT.UseParamRef_Final <- TADA_CreateUseParamRef(
+MT.UseParamRef.Final <- TADA_CreateUseParamRef(
   tada.MT.clean,
   org_id = c("MTDEQ"),
-  paramRef = MT.ParamRef_Final,
-  useParamRef = MT.UseParamRef_user_supplied_Edit,
+  paramRef = MT.ParamRef.Final,
+  useParamRef = MT.UseParamRef.user.supplied.edit,
   auto_assign = "All",
   excel = FALSE
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
@@ -663,7 +663,7 @@ MT.UseParamRef_Final <- TADA_CreateUseParamRef(
 )
 
 # Test if the two data frames are same or not.
-identical(MT.UseParamRef_Final[1:5], MT.UseParamRef_user_supplied_Edit[1:5])
+identical(MT.UseParamRef.Final[1:5], MT.UseParamRef.user.supplied.edit[1:5])
 
 TADA_TableExport(MT.useParamRef_Final)
 ```
@@ -672,7 +672,7 @@ remove intermediate variable, keep only the crosswalk table that we will
 continue to use in the workflow.
 
 ```{r remove-intermediate-variables-useParam}
-rm(MT.UseParamRef_AutoAssign, MT.UseParam_user_supplied, MT.UseParamRef_Manual, MT.UseParamRef_Manual_Update)
+rm(MT.UseParamRef.AutoAssign, MT.UseParam.user.supplied, MT.UseParamRef.Manual, MT.UseParamRef.Manual.Update)
 ```
 
 # TADA_CreateMLSummaryRef(): Create and Define Spatial Reference Tables
@@ -701,9 +701,9 @@ If you would like to display all information even for sites with no WQP
 data, please choose displayNA = TRUE
 
 ```{r ML_Summary}
-MT.MLSummaryRef_ML <- TADA_CreateMLSummaryRef(
+MT.MLSummaryRef.ML <- TADA_CreateMLSummaryRef(
   .data = tada.MT.clean,
-  useParamRef = MT.UseParamRef_Final,
+  useParamRef = MT.UseParamRef.AutoAssign,
   org_id = "MTDEQ",
   displayNA = FALSE
 )
@@ -727,9 +727,9 @@ your WQP data query. If you would like to display all information even
 for sites with no WQP data, please choose displayNA = TRUE
 
 ```{r AU_Summary, eval = FALSE}
-MT.MLSummaryRef_AU <- TADA_CreateMLSummaryRef(
+MT.MLSummaryRef.AU <- TADA_CreateMLSummaryRef(
   .data = tada.MT.clean,
-  useParamRef = MT.UseParamRef_Final,
+  useParamRef = MT.UseParamRef.Final,
   useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
   AUMLRef = Final.MT.AUMLRef,
   org_id = "MTDEQ"
@@ -746,7 +746,7 @@ certain combination of characteristics that have site-specific criteria.
 Let's go through an example of how a user may modify this table.
 
 ```{r apply-site-specific-criteria}
-MT.MLSummaryRef_AU2 <- MT.MLSummaryRef_AU %>%
+MT.MLSummaryRef.AU2 <- MT.MLSummaryRef.AU %>%
   dplyr::mutate(
     UniqueSpatialCriteria = dplyr::case_when(
       MonitoringLocationIdentifier == "MTVOLWQM_WQX-CLEARWATERR_1" ~ "Example Site Specific"
@@ -766,8 +766,8 @@ This could be included in the final summary table and labeled as NA or
 insufficient data.)
 
 ```{r compare-AU-versus-ML-Summary,, eval = FALSE}
-nrow(MT.MLSummaryRef_AU)
-nrow(MT.MLSummaryRef_ML)
+nrow(MT.MLSummaryRef.AU)
+nrow(MT.MLSummaryRef.ML)
 ```
 
 # TADA DefineCriteriaMethodology()
@@ -787,7 +787,7 @@ allowable values and easy interface for inputs to the table.
 MT.CriteriaMethods <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef_ML,
+  MLSummaryRef = MT.MLSummaryRef.ML,
   excel = FALSE
   # excel = TRUE, overwrite = TRUE
 )
@@ -803,10 +803,10 @@ TRUE/FALSE in the R documentation for more information) that are not
 captured in their user supplied table.
 
 ```{r user-supplied-output}
-MT.CriteriaMethods_user_supplied <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.user.supplied <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef_ML,
+  MLSummaryRef = MT.MLSummaryRef.ML,
   criteriaMethods = criteria_table,
   excel = FALSE
 )
@@ -819,10 +819,10 @@ all unique WQP Characteristic (or TADA.ComparableDataIdentifier) will be
 shown in the table.
 
 ```{r step-by-step-output-with-displayUniqueId}
-MT.CriteriaMethods_User_Supplied2 <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.User.Supplied2 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef_ML,
+  MLSummaryRef = MT.MLSummaryRef.ML,
   criteriaMethods = criteria_table,
   displayUniqueId = TRUE,
   excel = FALSE
@@ -833,10 +833,10 @@ You can append epa304a recommended standards (if there is one found for
 a TADA.CharacteristicName)
 
 ```{r append-epa304a-recommended-standards}
-MT.CriteriaMethods_User_Supplied3 <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.User.Supplied3 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  MLSummaryRef = MT.MLSummaryRef_ML,
+  MLSummaryRef = MT.MLSummaryRef.ML,
   criteriaMethods = criteria_table,
   displayUniqueId = TRUE,
   epa304a = TRUE,
@@ -859,7 +859,7 @@ in the remaining blank PH magnitude values with a range between 6.5 and
 
 ```{r finalize-criteria-table}
 # We will fill in PH magnitude values for this example
-MT.CriteriaMethods_Final <- MT.CriteriaMethods_User_Supplied3 %>%
+MT.CriteriaMethods.Final <- MT.CriteriaMethods.User.Supplied3 %>%
   dplyr::mutate(MagnitudeValueLower = dplyr::case_when(
     grepl("PH_NONE_NONE_NONE", TADA.ComparableDataIdentifier) & ATTAINS.OrganizationIdentifier == "MTDEQ" ~ 6.5,
     TRUE ~ MagnitudeValueLower
@@ -873,10 +873,10 @@ MT.CriteriaMethods_Final <- MT.CriteriaMethods_User_Supplied3 %>%
 We will supply this final crosswalk table to be reused and validated.
 
 ```{r re-use criteria table}
-MT.CriteriaMethods_Final2 <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.Final2 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
-  criteriaMethods = MT.CriteriaMethods_Final,
+  criteriaMethods = MT.CriteriaMethods.Final,
   displayUniqueId = TRUE,
   excel = FALSE
 )

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -619,7 +619,9 @@ consider for analysis.
 
 ```{r useparamref-User-Supplied}
 # Load the example MTDEQ criteria table
-criteria_table <- system.file("inst/extdata", "criteria_table.rda", package = "EPATADA")
+criteria_table <- system.file("extdata", "criteria_table.rda", package = "EPATADA")
+
+load(criteria_table)
 
 MT.UseParam.user.supplied <- dplyr::select(criteria_table, ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, TADA.CharacteristicName, ATTAINS.ParameterName, ATTAINS.UseName)
 

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -220,7 +220,7 @@ Before creating the TADA/WQP CharacteristicName and ATTAINS parameter
 crosswalk table (TADA_CreateParamRef), let's review all the unique
 TADA.ComparableDataIdentifier's (characteristic, fraction and speciation
 combinations) in the example data. How many results are available for
-each within the example data set (Data_NCTC)?
+each within the example data set?
 
 ```{r comparabledataID-counts}
 # create table with counts of TADA.ComparableDataIdentifiers
@@ -318,6 +318,8 @@ MT.ParamRef.None <- TADA_CreateParamRef(
   # uncomment to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.ParamRef.None)
 ```
 
 ### Auto_assign Options
@@ -338,6 +340,8 @@ MT.ParamRef.All <- TADA_CreateParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.ParamRef.All)
 ```
 
 Another option is to set auto_assign = 'Org'. This limits the exact
@@ -354,6 +358,8 @@ MT.ParamRef.Org <- TADA_CreateParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.ParamRef.Org)
 ```
 
 ### Manual Parameter Crosswalk
@@ -397,6 +403,8 @@ MT.ParamRef.Manual <- TADA_CreateParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.ParamRef.Manual)
 ```
 
 ### Provide a User Supplied paramRef
@@ -416,6 +424,8 @@ MT.ParamRef.user.supplied <- TADA_CreateParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.ParamRef.user.supplied)
 ```
 
 ### Review, Save and Re-Use paramRef
@@ -506,6 +516,8 @@ MT.UseParamRef.Manual <- TADA_CreateUseParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.UseParamRef.Manual)
 ```
 
 If desired, a user can manually assign "PH, HIGH" to any applicable uses
@@ -635,6 +647,8 @@ MT.UseParamRef.user.supplied.edit <- TADA_CreateUseParamRef(
   # uncomment excel = TRUE, overwrite = TRUE to run the excel file
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.UseParamRef.user.supplied.edit)
 ```
 
 ### Review, Save and Re-Use useParamRef
@@ -710,6 +724,8 @@ MT.MLSummaryRef.ML <- TADA_CreateMLSummaryRef(
   org_id = "MTDEQ",
   displayNA = FALSE
 )
+
+TADA_TableExport(MT.MLSummaryRef.ML)
 ```
 
 ## Define Spatial Summary by Monitoring Location (AU)
@@ -741,6 +757,8 @@ MT.MLSummaryRef.AU <- TADA_CreateMLSummaryRef(
   org_id = "MTDEQ"
   # displayNA = FALSE
 )
+
+TADA_TableExport(MT.MLSummaryRef.AU)
 ```
 
 ## Assign site-specific spatial criteria
@@ -758,6 +776,8 @@ MT.MLSummaryRef.AU2 <- MT.MLSummaryRef.AU %>%
       MonitoringLocationIdentifier == "MTVOLWQM_WQX-CLEARWATERR_1" ~ "Example Site Specific"
     )
   )
+
+TADA_TableExport(MT.MLSummaryRef.AU2)
 ```
 
 Compare the nrow for each of the ML versus AU level of summary. The AU
@@ -797,6 +817,8 @@ MT.CriteriaMethods <- TADA_DefineCriteriaMethodology(
   excel = FALSE
   # excel = TRUE, overwrite = TRUE
 )
+
+TADA_TableExport(MT.CriteriaMethods)
 ```
 
 Now, if MTDEQ, already has a filled out/partially filled out criteria
@@ -817,13 +839,15 @@ MT.CriteriaMethods.user.supplied <- TADA_DefineCriteriaMethodology(
   criteriaMethods = criteria_table,
   excel = FALSE
 )
+
+TADA_TableExport(MT.CriteriaMethods.user.supplied)
 ```
 
 You can append epa304a recommended standards (if there is one found for
 a TADA.CharacteristicName)
 
 ```{r append-epa304a-recommended-standards}
-MT.CriteriaMethods.User.Supplied2 <- TADA_DefineCriteriaMethodology(
+MT.CriteriaMethods.user.supplied2 <- TADA_DefineCriteriaMethodology(
   .data = tada.MT.clean,
   org_id = "MTDEQ",
   MLSummaryRef = NULL,
@@ -832,6 +856,8 @@ MT.CriteriaMethods.User.Supplied2 <- TADA_DefineCriteriaMethodology(
   epa304a = TRUE,
   excel = FALSE
 )
+
+TADA_TableExport(MT.CriteriaMethods.user.supplied2)
 ```
 
 ### Review, Save and Re-Use Criteria and Methodology Table
@@ -849,7 +875,7 @@ in the remaining blank PH magnitude values with a range between 6.5 and
 
 ```{r finalize-criteria-table}
 # We will fill in PH magnitude values for this example
-MT.CriteriaMethods.Final <- MT.CriteriaMethods.User.Supplied2 %>%
+MT.CriteriaMethods.Final <- MT.CriteriaMethods.user.supplied2 %>%
   dplyr::mutate(MagnitudeValueLower = dplyr::case_when(
     grepl("PH_NONE_NONE_NONE", TADA.ComparableDataIdentifier) & ATTAINS.OrganizationIdentifier == "MTDEQ" ~ 6.5,
     TRUE ~ MagnitudeValueLower
@@ -858,6 +884,8 @@ MT.CriteriaMethods.Final <- MT.CriteriaMethods.User.Supplied2 %>%
     grepl("PH_NONE_NONE_NONE", TADA.ComparableDataIdentifier) & ATTAINS.OrganizationIdentifier == "MTDEQ" ~ 8.5,
     TRUE ~ MagnitudeValueUpper
   ))
+
+TADA_TableExport(MT.CriteriaMethods.Final)
 ```
 
 We will supply this final crosswalk table to be reused and validated.
@@ -871,4 +899,6 @@ MT.CriteriaMethods.Final2 <- TADA_DefineCriteriaMethodology(
   displayUniqueId = TRUE,
   excel = FALSE
 )
+
+TADA_TableExport(MT.CriteriaMethods.Final2)
 ```

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -619,7 +619,7 @@ consider for analysis.
 
 ```{r useparamref-User-Supplied}
 # Load the example MTDEQ criteria table
-load("C:/Users/kwong01/EPATADA/inst/extdata/criteria_table.rda")
+criteria_table <- system.file("inst/extdata", "criteria_table.rda", package = "EPATADA")
 
 MT.UseParam.user.supplied <- dplyr::select(criteria_table, ATTAINS.OrganizationIdentifier, TADA.ComparableDataIdentifier, TADA.CharacteristicName, ATTAINS.ParameterName, ATTAINS.UseName)
 

--- a/vignettes/ExampleMod3Workflow.Rmd
+++ b/vignettes/ExampleMod3Workflow.Rmd
@@ -73,7 +73,7 @@ Dependency packages will also be downloaded automatically from CRAN. You
 may be prompted in the console to update dependencies. It is recommended
 to update all dependencies (enter 1 into the console).
 
-```{r install_TADA, eval = T, results = 'hide'}
+```{r install_TADA, eval = F, results = 'hide'}
 remotes::install_github("USEPA/EPATADA",
   ref = "develop",
   dependencies = TRUE
@@ -161,6 +161,7 @@ reference tables were created, see the ExampleMod2Workflow vignette.
 ```{r load-data}
 # import example data set, example AUML crosswalk and example uses to AU crosswalk.
 # extract ATTAINS_crosswalk data frame from the list
+utils::data(Data_MT_AUMLRef)
 Final.MT.AUMLRef <- Data_MT_AUMLRef$ATTAINS_crosswalk
 
 MT.UseAURef <- Data_MT_UseAURef
@@ -665,7 +666,7 @@ MT.UseParamRef.Final <- TADA_CreateUseParamRef(
 # Test if the two data frames are same or not.
 identical(MT.UseParamRef.Final[1:5], MT.UseParamRef.user.supplied.edit[1:5])
 
-TADA_TableExport(MT.useParamRef.Final)
+TADA_TableExport(MT.UseParamRef.Final)
 ```
 
 remove intermediate variable, keep only the crosswalk table that we will
@@ -727,10 +728,13 @@ your WQP data query. If you would like to display all information even
 for sites with no WQP data, please choose displayNA = TRUE
 
 ```{r AU_Summary, eval = FALSE}
+# Load the dataset
+utils::data("Data_MT.UseAURef_Water", package = "EPATADA")
+
 MT.MLSummaryRef.AU <- TADA_CreateMLSummaryRef(
   .data = tada.MT.clean,
   useParamRef = MT.UseParamRef.Final,
-  useAURef = MT.UseAURef_with_WaterUseRef, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
+  useAURef = Data_MT.UseAURef_Water, # uses will come from the user supplied reference table produced in ExampleMod2Workflow.Rmd
   AUMLRef = Final.MT.AUMLRef,
   org_id = "MTDEQ"
   # displayNA = FALSE
@@ -745,7 +749,7 @@ that needs a unique site-specific criteria, certain water types, or
 certain combination of characteristics that have site-specific criteria.
 Let's go through an example of how a user may modify this table.
 
-```{r apply-site-specific-criteria}
+```{r apply-site-specific-criteria, eval = FALSE}
 MT.MLSummaryRef.AU2 <- MT.MLSummaryRef.AU %>%
   dplyr::mutate(
     UniqueSpatialCriteria = dplyr::case_when(


### PR DESCRIPTION
some minor updates to handle errors in the mod 3 vignette.

- minor code cleanup
- mod3 vignette error handling - examples should run fine now (please review). Test out TADA_CreateParamRef with multiple org_id, and test with auto_assign = "Org" or "All" to see if the output is running as expected. Ex. `MT.ParamRef.All <- TADA_CreateParamRef(
  tada.MT.clean,
  org_id = c("MTDEQ", "MDE_EASP", "21ARIZ"),
  auto_assign = "Org",
  excel = FALSE
)`
- TADA_DefineCriteriaMethodology() handling of invalid arg input combos was done. This function can now handle multiple org_ids correctly as well. See ExampleMod3AltOptions vignette and test out the scenarios for multiple org_id. Ex. 
- `MT.Criteria.auto3 <- TADA_DefineCriteriaMethodology(
  tada.MT.clean,
  org_id = c("MTDEQ","MDE_EASP", "21ARIZ"), # add other org_id to see output
  auto_assign = TRUE,
  epa304a = TRUE,
  displayUniqueId = TRUE,
  excel = FALSE
)`