### PR TITLE
Update DepthProfile.R

### DIFF
--- a/R/DepthProfile.R
+++ b/R/DepthProfile.R
@@ -908,12 +908,12 @@ TADA_IDDepthProfiles <- function(
 #' # Create a depth profile figure with three parameters for a single
 #' # monitoring location and date
 #' TADA_DepthProfilePlot(Data_6Tribes_5y_Harmonized,
-#'   groups = c(
-#'     "TEMPERATURE_NA_NA_DEG C", "PH_NA_NA_STD UNITS",
-#'     "DEPTH, SECCHI DISK DEPTH_NA_NA_M"
-#'   ),
-#'   location = "REDLAKE_WQX-ANKE",
-#'   activity_date = "2018-10-04"
+#' groups = c(
+#'  "TEMPERATURE_NONE_NONE_DEG C", "PH_NONE_NONE_NONE",
+#'  "DEPTH, SECCHI DISK DEPTH_NONE_NONE_M"
+#' ),
+#' location = "REDLAKE_WQX-ANKE",
+#' activity_date = "2018-10-04"
 #' )
 #'
 #' # Load example data frame:
@@ -921,10 +921,10 @@ TADA_IDDepthProfiles <- function(
 #' # Create a depth profile figure with two parameters for a single monitoring
 #' # location and date without displaying depth categories
 #' TADA_DepthProfilePlot(Data_6Tribes_5y_Harmonized,
-#'   groups = c("CONDUCTIVITY_NA_NA_US/CM", "DISSOLVED OXYGEN (DO)_NA_NA_MG/L"),
-#'   location = "REDLAKE_WQX-JOHN",
-#'   activity_date = "2018-07-31",
-#'   depthcat = FALSE
+#' groups = c("PH_NONE_NONE_NONE", "DISSOLVED OXYGEN (DO)_NONE_NONE_MG/L"),
+#' location = "REDLAKE_WQX-JOHN",
+#' activity_date = "2018-07-31",
+#'depthcat = FALSE
 #' )
 #' }
 #'


### PR DESCRIPTION
Closes #912 

The issue Jimmy noticed when working on the depth profile plots has already been fixed in other recent EPATADA package updates. However, when testing, I noticed the depth profile plot examples needed to be updated to reflect new TADA.ComparableDataIdentifiers (using NONE instead of NA) to run correctly.

This is very simple PR - all it includes are the updated depth profile plot examples.