### PR TITLE
Bug fixes for correct col type and org_id message 

### DIFF
--- a/R/ATTAINSCrosswalks.R
+++ b/R/ATTAINSCrosswalks.R
@@ -3205,16 +3205,17 @@ TADA_AssignUsesToAU <- function(
           ATTAINS.AssessmentUnitIdentifier,
           ATTAINS.WaterType,
           ATTAINS.OrganizationIdentifier
-        )
+        ) |>
+        TADA_CorrectColType()
     }
 
     # if null, creates a list of all unique TADA.ComparableDataIdentifier, but no org populated.
     if (!is.character(org_id) & is.null(org_id)) {
       org_id <- ""
+      message(
+        "Proceeding function with 'org_id = NULL'. If this was not intentional, please supply a valid 'org_id'."
+      )
     }
-    message(
-      "Proceeding function with 'org_id = NULL'. If this was not intentional, please supply a valid 'org_id'."
-    )
 
     # if org_id = all, create a crosswalk for all ATTAINS org in the data frame.
     if (tolower("all") %in% tolower(org_id)) {
@@ -3292,7 +3293,8 @@ TADA_AssignUsesToAU <- function(
     OrgID_assessments <- dplyr::filter(
       OrgID_assessments,
       assessmentUnitId %in% unique(AUMLRef$ATTAINS.AssessmentUnitIdentifier)
-    )
+    ) |>
+      TADA_CorrectColType()
 
     # Joins Existing Uses to Existing AUs in your AUMLRef dataframe. Non-matches are flagged as New AU.
     CreateAU_UsesRef <- AUMLRef |>


### PR DESCRIPTION
### Pull Request Checklist (convert PR to draft if in progress)

This PR corrects some additional issues that cause problems when running TADAShinyJoinToAU. Specifically, it adds the TADA_CorrectCol type function in a couple of places where user inputs can cause joins to fail due to inconsistent types. It also moves a printed message stating that org_id = NULL is being used so that it is printed only when org_id is actually NULL. Previously, it was always printed.

Required 

-   [x] Update your branch from the latest `develop` and resolve any merge conflicts

-   [x] Run devtools::test(), devtools::check(), and devtools::document() locally; ensure tests pass and fix any errors, warnings, or notes. Add new dependencies to `DESCRIPTION` and document appropriately

-   [x] Add/update vignettes for corresponding changes in functionality, list these under articles in _pkgdown.yml, and ensure added/updated vignettes run and build with proper formatting locally

-   [x] Request review from at least one developer team member (convert PR to ready for review if it was designated as in progress)

Best practices

-   [x] Include a summary of the changes made and relevant context/motivation

-   [x] Link issues to auto-close on merge (use Development sidebar or include "Closes #<issue-number>" in the PR)

-   [x] Refresh inline/block comments for clarity

-   [x] Update roxygen docs and include examples; review help pages

-   [x] Add/update tests in `tests/testthat`; review the bot's coverage report from [test-coverage](https://github.com/USEPA/EPATADA/blob/develop/.github/workflows/test-coverage.yaml) and confirm all changes are covered

Conditional

-   [x] If there is a bot spelling comment, run spelling::spell_check_package() locally and fix any misspellings; add approved project terms to WORDLIST with spelling::update_wordlist()

-   [x] If tests fail suggesting internal reference files need a refresh, run `.TADA_UpdateRefFiles()` and `.TADA_UpdateExampleData()` locally via `MaintenanceScheduled.R` or trigger the [Component File Update](https://github.com/USEPA/EPATADA/actions/workflows/maintenance-update.yaml) GitHub Action

-   [x] If new example data files were added, document them in `ExampleData.R` and include them in `MaintenanceScheduled.R` for regular refresh

-   [x] If columns were added/updated, update `RequiredCols.R`

-   [x] If changes affect other package or the shiny app functions, update those impacted functions accordingly
